### PR TITLE
Fix `build(VM, bool)` and add `build(VM, const char*)`.

### DIFF
--- a/vm/main/array.hh
+++ b/vm/main/array.hh
@@ -77,7 +77,7 @@ UnstableNode Array::arrayGet(Self self, VM vm, RichNode index) {
 
 void Array::arrayPut(Self self, VM vm, RichNode index, RichNode value) {
   if (!isHomedInCurrentSpace(vm))
-    raise(vm, MOZART_STR("globalState"), "array");
+    raise(vm, MOZART_STR("globalState"), MOZART_STR("array"));
 
   self[getOffset(self, vm, index)].copy(vm, value);
 }
@@ -85,7 +85,7 @@ void Array::arrayPut(Self self, VM vm, RichNode index, RichNode value) {
 UnstableNode Array::arrayExchange(Self self, VM vm, RichNode index,
                                   RichNode newValue) {
   if (!isHomedInCurrentSpace(vm))
-    raise(vm, MOZART_STR("globalState"), "array");
+    raise(vm, MOZART_STR("globalState"), MOZART_STR("array"));
 
   size_t offset = getOffset(self, vm, index);
 

--- a/vm/main/corebuilders.hh
+++ b/vm/main/corebuilders.hh
@@ -84,8 +84,10 @@ UnstableNode build(VM vm, internal::int64IfDifferentFromNativeInt value) {
   return SmallInt::build(vm, (nativeint) value);
 }
 
+template <typename T>
 inline
-UnstableNode build(VM vm, bool value) {
+auto build(VM vm, T value)
+    -> typename std::enable_if<std::is_same<T, bool>::value, UnstableNode>::type {
   return Boolean::build(vm, value);
 }
 
@@ -102,6 +104,18 @@ UnstableNode build(VM vm, double value) {
 inline
 UnstableNode build(VM vm, const nchar* value) {
   return Atom::build(vm, value);
+}
+
+// build an atom from a 'const char*' (as UTF string).
+// Only exists when 'nchar != char'.
+template <typename T>
+inline
+auto build(VM vm, T value)
+    -> typename std::enable_if<std::is_convertible<T, const char*>::value &&
+                               !std::is_same<nchar, char>::value, UnstableNode>::type {
+  auto src = makeLString(value);
+  auto dest = toUTF<nchar>(src);
+  return Atom::build(vm, dest.length, dest.string);
 }
 
 inline

--- a/vm/main/dictionary.hh
+++ b/vm/main/dictionary.hh
@@ -479,7 +479,7 @@ UnstableNode Dictionary::dictCondGet(Self self, VM vm, RichNode feature,
 void Dictionary::dictPut(Self self, VM vm, RichNode feature,
                          RichNode newValue) {
   if (!isHomedInCurrentSpace(vm))
-    return raise(vm, MOZART_STR("globalState"), "dictionary");
+    return raise(vm, MOZART_STR("globalState"), MOZART_STR("dictionary"));
 
   requireFeature(vm, feature);
 
@@ -492,7 +492,7 @@ void Dictionary::dictPut(Self self, VM vm, RichNode feature,
 UnstableNode Dictionary::dictExchange(Self self, VM vm, RichNode feature,
                                       RichNode newValue) {
   if (!isHomedInCurrentSpace(vm))
-    raise(vm, MOZART_STR("globalState"), "dictionary");
+    raise(vm, MOZART_STR("globalState"), MOZART_STR("dictionary"));
 
   requireFeature(vm, feature);
 
@@ -510,7 +510,7 @@ UnstableNode Dictionary::dictCondExchange(Self self, VM vm, RichNode feature,
                                           RichNode defaultValue,
                                           RichNode newValue) {
   if (!isHomedInCurrentSpace(vm))
-    raise(vm, MOZART_STR("globalState"), "dictionary");
+    raise(vm, MOZART_STR("globalState"), MOZART_STR("dictionary"));
 
   requireFeature(vm, feature);
 
@@ -527,7 +527,7 @@ UnstableNode Dictionary::dictCondExchange(Self self, VM vm, RichNode feature,
 
 void Dictionary::dictRemove(Self self, VM vm, RichNode feature) {
   if (!isHomedInCurrentSpace(vm))
-    return raise(vm, MOZART_STR("globalState"), "dictionary");
+    return raise(vm, MOZART_STR("globalState"), MOZART_STR("dictionary"));
 
   requireFeature(vm, feature);
 
@@ -536,7 +536,7 @@ void Dictionary::dictRemove(Self self, VM vm, RichNode feature) {
 
 void Dictionary::dictRemoveAll(Self self, VM vm) {
   if (!isHomedInCurrentSpace(vm))
-    return raise(vm, MOZART_STR("globalState"), "dictionary");
+    return raise(vm, MOZART_STR("globalState"), MOZART_STR("dictionary"));
 
   dict.removeAll(vm);
 }


### PR DESCRIPTION
Because C++ allows implicitly converting a pointer to bool, the following program will wrongly create a Boolean instead of an Atom or emit a compile-time error. This, for example, makes `OS.getEnv` returns just `true` instead of a real String/Atom.

``` c++
#include <iostream>
#include <mozart.hh>

using namespace mozart;

struct TestEnvironment : VirtualMachineEnvironment {
    TestEnvironment() : VirtualMachineEnvironment(true) {}

    virtual UUID genUUID() {
        return UUID("{8303bb2b-2d34-42e6-9726-7834ede651f1}");
    }
};

int main() {
    TestEnvironment environment;
    VirtualMachine virtual_machine (environment);
    VM vm (&virtual_machine);

    const char* foo = "1234";
    auto node = build(vm, foo);
    std::cout << repr(vm, node) << std::endl;    // prints 'true'

    return 0;
}
```

This pull request fixes the signature of `build` to only accept real booleans in `build(vm, bool)`. Also, I added `build(vm, const char*)` to perform the UTF-8-to-16 conversion and produce an atom. 
