### PR TITLE
Better support for the OPI on Mac OS

### DIFF
--- a/macos/startup
+++ b/macos/startup
@@ -5,4 +5,23 @@ OZHOME="$MOZART_BUNDLE/Contents/Resources/"
 
 export OZHOME
 
-/Applications/Aquamacs.app/Contents/MacOS/Aquamacs --eval '(setq load-path (cons "'$OZHOME'/share/mozart/elisp" load-path))' -l oz.elc -f run-oz $2 &
+AQUAMACS="/Applications/Aquamacs.app/Contents/MacOS/Aquamacs"
+EMACS="/Applications/Emacs.app/Contents/MacOS/Emacs"
+OPIEMACS=""
+
+if [ -f $AQUAMACS ];
+then
+  OPIEMACS=$AQUAMACS
+else
+  if [ -f $EMACS ];
+  then
+    OPIEMACS=$EMACS
+  fi
+fi
+
+if [ -z "$OPIEMACS" ];
+then
+  osascript -e "tell application \"Finder\"" -e "display dialog \"No emacs application found. Visit:\n htpp://http://aquamacs.org/ or\n http://emacsformacosx.com/ \nand install it in the Applications folder.\"" -e "end tell"
+else
+  $OPIEMACS --eval '(setq load-path (cons "'$OZHOME'/share/mozart/elisp" load-path))' -l oz.elc -f run-oz $2 &
+fi


### PR DESCRIPTION
The two most widely known versions of emacs for the mac are supported/
