### PR TITLE
Fixes #46: badOpCode with createXYZUnifyK().

### DIFF
--- a/vm/vm/main/emulate.cc
+++ b/vm/vm/main/emulate.cc
@@ -792,6 +792,11 @@ void Thread::run() {
         case OpCreateTupleUnifyG:
         case OpCreateRecordUnifyG:
 
+        case OpCreateAbstractionUnifyK:
+        case OpCreateConsUnifyK:
+        case OpCreateTupleUnifyK:
+        case OpCreateRecordUnifyK:
+
         {
           auto what = op & OpCreateStructWhatMask;
           auto where = op & OpCreateStructWhereMask;


### PR DESCRIPTION
Trivial fix. All the infrastructure was there. I had only forgotten to list these 4 opcodes in the emulator big switch. -_-'
