### PR TITLE
Fixes #47: the assembler blocks if given an unbound K.

### DIFF
--- a/lib/compiler/NewAssembler.oz
+++ b/lib/compiler/NewAssembler.oz
@@ -28,6 +28,7 @@ require
    BootSerializer at 'x-oz://boot/Serializer'
 
 import
+   System
    CompilerSupport
 
 export
@@ -289,6 +290,21 @@ define
       end
    end
 
+   fun {NonBlockingEqEq X Y}
+      if {System.eq X Y} then
+         true
+      elseif {Not {IsDet X} andthen {IsDet Y}} then
+         false
+      elseif {IsRecord X} andthen {IsRecord Y} then
+         Ar = {Arity X}
+      in
+         {Label X} == {Label Y} andthen Ar == {Arity Y} andthen
+         {All Ar fun {$ F} {NonBlockingEqEq X.F Y.F} end}
+      else
+         X == Y
+      end
+   end
+
    class InternalAssemblerClass
       prop final
 
@@ -385,7 +401,7 @@ define
 
       meth GetKRegForInternal(Value ?Result KRegCount KRegs)
          case KRegs
-         of H|_ andthen H == Value then
+         of H|_ andthen {NonBlockingEqEq H Value} then
             Result = KRegCount-1
          [] _|T then
             {self GetKRegForInternal(Value ?Result KRegCount-1 T)}


### PR DESCRIPTION
Fixes #47.

The assembler tries and merge common constants in K
registers. It used to do that using `==` to compare
different K's, which of course blocked on unbound
values.

This fixes introduces a function `NonBlockingEqEq` that
does not block on its operands (nor touches them in any
way, i.e., does not make them needed). It answers `true`
when it can decide that the two values are equal, and
`false` in other cases.
