### PR TITLE
Use std::atomic values for inter-threads fields of VM.

### DIFF
--- a/vm/vm/main/vm.hh
+++ b/vm/vm/main/vm.hh
@@ -50,7 +50,11 @@ void BuiltinModule::initModule(VM vm, T&& module) {
 void registerCoreModules(VM vm);
 
 VirtualMachine::VirtualMachine(VirtualMachineEnvironment& environment):
-  rootGlobalNode(nullptr), environment(environment), gc(this), sc(this) {
+  rootGlobalNode(nullptr), environment(environment), gc(this), sc(this),
+  _preemptRequestedNot(ATOMIC_FLAG_INIT),
+  _exitRunRequestedNot(ATOMIC_FLAG_INIT),
+  _gcRequestedNot(ATOMIC_FLAG_INIT),
+  _referenceTime(0) {
 
   memoryManager.init();
 
@@ -65,10 +69,9 @@ VirtualMachine::VirtualMachine(VirtualMachineEnvironment& environment):
   _cleanupList = nullptr;
 
   _envUseDynamicPreemption = environment.useDynamicPreemption();
-  _preemptRequested = false;
-  _exitRunRequested = false;
-  _gcRequested = false;
-  _referenceTime = 0;
+  _preemptRequestedNot.test_and_set();
+  _exitRunRequestedNot.test_and_set();
+  _gcRequestedNot.test_and_set();
 
   initialize();
 
@@ -81,7 +84,7 @@ VirtualMachine::~VirtualMachine() {
 }
 
 bool VirtualMachine::testPreemption() {
-  return _preemptRequested ||
+  return testAndClearPreemptRequested() ||
     (_envUseDynamicPreemption && environment.testDynamicPreemption()) ||
     gc.isGCRequired();
 }
@@ -130,7 +133,7 @@ UUID VirtualMachine::genUUID() {
 }
 
 void VirtualMachine::setAlarm(std::int64_t delay, StableNode* wakeable) {
-  std::int64_t expiration = _referenceTime + delay;
+  std::int64_t expiration = getReferenceTime() + delay;
 
   auto iter = _alarms.removable_begin();
   while ((iter != _alarms.removable_end()) && (iter->expiration < expiration))


### PR DESCRIPTION
This pull request solves a long-lived TODO: replacing the `volatile` keyword used for inter-threads fields of VM by C++11 atomic types. The `volatile` keyword had plain wrong semantics for these fields, but seemed to be an acceptable substitute to atomic types at the time of writing that code, since atomic types were not supported by libstdc++ back then.

This pull request must be compiled and tested with clang on a Mac OS before being approved. I'm not sure at all that clang and libc++ support atomic types yet. Although apparently it does, since it passed the "generator" stage, which uses clang.
