### PR TITLE
Fixes #65: VM unit tests about GC broken.

### DIFF
--- a/vm/vm/test/gctest.cc
+++ b/vm/vm/test/gctest.cc
@@ -10,6 +10,10 @@ TEST_F(GCTest, GCSanity) {
     // This is to ensure the GC does release memory allocated on the VM, and to
     // ensure 'requestGC' does invoke the GC when the VM is running.
 
+    // 0. Start in a non-degenerate case
+    vm->requestGC();
+    vm->run();
+
     // 1. Check that the size does increase after we allocate something.
     size_t original_size = vm->getMemoryManager().getAllocated();
     auto unit_node = build(vm, unit);
@@ -32,6 +36,10 @@ TEST_F(GCTest, GCSanity) {
 TEST_F(GCTest, Protect) {
     // This is to ensure protected nodes are noticed by GC, and thus won't be
     // freed.
+
+    // 0. Start in a non-degenerate case
+    vm->requestGC();
+    vm->run();
 
     // 1. Check that the size does increase after we allocate something.
     size_t original_size = vm->getMemoryManager().getAllocated();


### PR DESCRIPTION
Fixes #65: VM unit tests about GC broken.

From VM instantiation to first GC ever, the
VM is in a degenerate case that cannot be
reached again after subsequent GC runs.

The two first tests (which check the exact
amount of bytes allocated) must therefore
run a first GC before they measure the
original_size (the amount of bytes allocated
in an "empty" VM).
