### PR TITLE
Do not link to librt if not available (e.g.: OS X)

### DIFF
--- a/boosthost/emulator/CMakeLists.txt
+++ b/boosthost/emulator/CMakeLists.txt
@@ -52,7 +52,10 @@ target_link_libraries(ozemulator mozartvmboost mozartvm ${Boost_LIBRARIES})
 
 # Here it starts to differ wildly on Windows
 if(NOT WIN32)
-  target_link_libraries(ozemulator pthread rt)
+  target_link_libraries(ozemulator pthread)
+  if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(rt)
+  endif()
 
   # Install
   install(TARGETS ozemulator DESTINATION bin)


### PR DESCRIPTION
In cab071ad, librt is linked, but this fails on OS X as there is no librt: `ld: library not found for -lrt`

I used the same condition as http://stackoverflow.com/questions/7695638/conditional-cmake-link-to-rt-library, maybe there is a better one.

BTW, why is `${CMAKE_SYSTEM_NAME} MATCHES "Darwin"` used instead of `APPLE`?
http://www.cmake.org/cmake/help/v2.8.8/cmake.html#section_VariablesThatDescribetheSystem
