### PR TITLE
Re-enable string tests and ByteString.stringSearch on OS X.

### DIFF
--- a/vm/vm/main/bytestring.hh
+++ b/vm/vm/main/bytestring.hh
@@ -117,11 +117,6 @@ void ByteString::stringSearch(
   RichNode self, VM vm, RichNode from, RichNode needleNode,
   UnstableNode& begin, UnstableNode& end) {
 
-  // TODO Fix this - it was deactivated because of a build problem on Mac OS
-#ifdef __llvm__ // or is it __clang__?
-  raiseError(vm, "notImplemented",
-             "ByteString::stringSearch");
-#else
   using namespace patternmatching;
 
   auto fromOffset = getArgument<nativeint>(vm, from, "integer");
@@ -164,9 +159,7 @@ void ByteString::stringSearch(
       begin = SmallInt::build(vm, foundOffset);
       end = SmallInt::build(vm, foundOffset + needle->length);
     }
-
   }
-#endif
 }
 
 bool ByteString::stringHasPrefix(VM vm, RichNode prefixNode) {

--- a/vm/vm/main/coremodules.cc
+++ b/vm/vm/main/coremodules.cc
@@ -73,4 +73,9 @@ void registerCoreModules(VM vm) {
   registerBuiltinModWeakReference(vm);
 }
 
+// Workaround a problem which LString.slice() is a undefined symbol in this file.
+namespace mut {
+  template struct LString<unsigned char>;
+}
+
 } // namespace mozart

--- a/vm/vm/test/CMakeLists.txt
+++ b/vm/vm/test/CMakeLists.txt
@@ -29,17 +29,9 @@ include_directories("${GTEST_SRC_DIR}" "${GTEST_SRC_DIR}/include")
 
 # The testing executable
 
-set(VMTEST_SRCS testutils.cc sanitytest.cc smallinttest.cc floattest.cc
-  atomtest.cc gctest.cc)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  message(WARNING "String tests are disabled on this platform")
-else()
-  list(APPEND VMTEST_SRCS coderstest.cc utftest.cc stringtest.cc
-    virtualstringtest.cc bytestringtest.cc)
-endif()
-
-add_executable(vmtest ${VMTEST_SRCS})
+add_executable(vmtest testutils.cc sanitytest.cc smallinttest.cc floattest.cc
+  atomtest.cc gctest.cc coderstest.cc utftest.cc stringtest.cc
+  virtualstringtest.cc bytestringtest.cc)
 target_link_libraries(vmtest mozartvm custom_gtest custom_gtest_main)
 
 if(NOT MINGW)


### PR DESCRIPTION
Revert f508bcf with workaround using explicit instantiation.

(Only tested on OS X 10.8.)

Since the problem is undefined symbol in coremodules.o, we could just explicitly instantiate LString<unsigned char> there. `vmtest` works fine after this.

Re-enabled string tests and ByteString.stringSearch.
