### PR TITLE
Fix issue #85: Serialized code area size is doubled.

### DIFF
--- a/vm/vm/main/codearea.hh
+++ b/vm/vm/main/codearea.hh
@@ -100,7 +100,7 @@ void CodeArea::printReprToStream(VM vm, std::ostream& out,
 UnstableNode CodeArea::serialize(VM vm, SE se) {
   UnstableNode codeAtom = mozart::build(vm, "code");
   UnstableNode block = buildTupleDynamic(
-    vm, codeAtom, _size, _codeBlock,
+    vm, codeAtom, _size / sizeof(ByteCode), _codeBlock,
     [=](ByteCode b) {
       return mozart::build(vm, (nativeint) b);
     });


### PR DESCRIPTION
(#85)

Cause: `buildTupleDynamic()` expects the number of elements, but `CodeArea::_size` is the byte-size of the byte codes, which is 2x the array length if passed as is.
