### PR TITLE
Added `Reflection.becomeExchange` and `Reflection.isReflectiveVariable`

### DIFF
--- a/vm/vm/main/modules/modreflection.hh
+++ b/vm/vm/main/modules/modreflection.hh
@@ -111,6 +111,19 @@ public:
       }
     }
   };
+
+  class BecomeExchange: public Builtin<BecomeExchange> {
+  public:
+    BecomeExchange(): Builtin("becomeExchange") {}
+
+    static void call(VM vm, In entity, In value, Out originalEntity) {
+      if (entity.type().getStructuralBehavior() == sbTokenEq) {
+        originalEntity = entity.becomeExchange(vm, value);
+      } else {
+        raiseTypeError(vm, "Token", entity);
+      }
+    }
+  };
 };
 
 }

--- a/vm/vm/main/store-decl.hh
+++ b/vm/vm/main/store-decl.hh
@@ -232,6 +232,8 @@ public:
     reinit(vm, std::forward<T>(value));
   }
 
+  inline UnstableNode becomeExchange(VM vm, RichNode value);
+
   inline
   std::string toDebugString();
 private:

--- a/vm/vm/main/store.hh
+++ b/vm/vm/main/store.hh
@@ -268,6 +268,21 @@ StableNode* RichNode::destOf(Node* node) {
   return node->access<Reference>().dest();
 }
 
+UnstableNode RichNode::becomeExchange(VM vm, RichNode value) {
+  // Move the *entire* content of the node to a new, unrelated unstable node.
+  // FIXME there should be a method without using memcpy...
+  UnstableNode result;
+  if (isStable()) {
+    auto stableRef = new (vm) StableNode;
+    memcpy(stableRef, &asStable(), sizeof(*stableRef));
+    result.init(vm, *stableRef);
+  } else {
+    memcpy(&result, &asUnstable(), sizeof(result));
+  }
+  become(vm, value);
+  return result;
+}
+
 ////////////////
 // GlobalNode //
 ////////////////


### PR DESCRIPTION
These are some new reflection methods which I find lacking when implementing the new DSS.
1. `Reflection.isReflectiveVariable` checks whether a node is a reflective variable.
2. `Reflection.becomeExchange` means makes all references to a node become another, and return the original value in another object. 
