### PR TITLE
Builds on Mavericks

### DIFF
--- a/boosthost/emulator/CMakeLists.txt
+++ b/boosthost/emulator/CMakeLists.txt
@@ -42,7 +42,10 @@ include_directories("${MOZART_DIR}/vm/boostenv/main"
 
 
 # Compile the executable
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND IS_DIRECTORY "/usr/lib/c++/v1")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND
+   (IS_DIRECTORY "/usr/lib/c++/v1" OR
+    IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/"
+   ))
   include_directories(/usr/lib/c++/v1)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()

--- a/vm/boostenv/main/CMakeLists.txt
+++ b/vm/boostenv/main/CMakeLists.txt
@@ -20,9 +20,21 @@ else()
   set(CXX_STD_OPT -std=c++0x)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND IS_DIRECTORY "/usr/lib/c++/v1")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  set(MOZART_GENERATOR_FLAGS "-I/usr/lib/c++/v1")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  if(IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
+    # Mavericks
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(MOZART_GENERATOR_FLAGS 
+        "-I/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
+    include_directories(/Library/Developer/CommandLineTools/usr/lib/c++/v1/)
+  elseif(IS_DIRECTORY "/usr/lib/c++/v1")
+    # Mountain Lion
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(MOZART_GENERATOR_FLAGS "-I/usr/lib/c++/v1")
+  else()
+    # Prior to Mountain Lion
+  endif()
 endif()
 
 # Mozart VM library

--- a/vm/generator/CMakeLists.txt
+++ b/vm/generator/CMakeLists.txt
@@ -1,7 +1,10 @@
 if("${LLVM_SRC_DIR}" STREQUAL "${DEFAULT_LLVM_SRC_DIR}" AND
    NOT EXISTS "${LLVM_BUILD_DIR}/bin/clang++")
 
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND IS_DIRECTORY "/usr/lib/c++/v1")
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND 
+     (IS_DIRECTORY "/usr/lib/c++/v1" OR
+      IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/"
+     ))
     set(LLVM_CMAKE_EXTRA_ARGS "-DCMAKE_CXX_FLAGS=-stdlib=libc++")
   endif()
 

--- a/vm/generator/main/CMakeLists.txt
+++ b/vm/generator/main/CMakeLists.txt
@@ -5,7 +5,10 @@ add_definitions(-D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS)
 
 set(CMAKE_CXX_FLAGS "-Wall -Wno-enum-compare -Wno-strict-aliasing -std=gnu++0x ${CMAKE_CXX_FLAGS}")
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND IS_DIRECTORY "/usr/lib/c++/v1")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND
+   (IS_DIRECTORY "/usr/lib/c++/v1" OR
+   IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
+  )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 

--- a/vm/vm/CMakeLists.txt
+++ b/vm/vm/CMakeLists.txt
@@ -1,7 +1,10 @@
 if("${GTEST_SRC_DIR}" STREQUAL "${DEFAULT_GTEST_SRC_DIR}" AND
    NOT EXISTS "${GTEST_BUILD_DIR}/libgtest.a")
 
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND IS_DIRECTORY "/usr/lib/c++/v1")
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND 
+     (IS_DIRECTORY "/usr/lib/c++/v1" OR 
+      IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/"
+     ))
     set(GTEST_CMAKE_EXTRA_ARGS "-DCMAKE_CXX_FLAGS=-stdlib=libc++")
   endif()
 
@@ -15,6 +18,7 @@ if("${GTEST_SRC_DIR}" STREQUAL "${DEFAULT_GTEST_SRC_DIR}" AND
 
   ExternalProject_Add(gtest
     SVN_REPOSITORY http://googletest.googlecode.com/svn/trunk
+    SVN_REVISION -r "662"
     CMAKE_ARGS ${GTEST_CMAKE_ARGS}
     INSTALL_COMMAND ""
     TEST_COMMAND ""

--- a/vm/vm/main/CMakeLists.txt
+++ b/vm/vm/main/CMakeLists.txt
@@ -2,18 +2,21 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   if(IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
+    message(STATUS "@@@@ should be on Mavericks")
     # Mavericks
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(MOZART_GENERATOR_FLAGS
         "-I/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
     include_directories(/Library/Developer/CommandLineTools/usr/lib/c++/v1/)
   elseif(IS_DIRECTORY "/usr/lib/c++/v1")
+    message(STATUS "@@@@ should be on ML")
     # Mountain Lion
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(MOZART_GENERATOR_FLAGS "-I/usr/lib/c++/v1")
     include_directories(/usr/lib/c++/v1)
   else()
     # Prior to Mountain Lion?
+    message(STATUS "@@@@ have no idea which darwin")
   endif()
 endif()
 

--- a/vm/vm/main/CMakeLists.txt
+++ b/vm/vm/main/CMakeLists.txt
@@ -2,21 +2,18 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   if(IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
-    message(STATUS "@@@@ should be on Mavericks")
     # Mavericks
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(MOZART_GENERATOR_FLAGS
         "-I/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
     include_directories(/Library/Developer/CommandLineTools/usr/lib/c++/v1/)
   elseif(IS_DIRECTORY "/usr/lib/c++/v1")
-    message(STATUS "@@@@ should be on ML")
     # Mountain Lion
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(MOZART_GENERATOR_FLAGS "-I/usr/lib/c++/v1")
     include_directories(/usr/lib/c++/v1)
   else()
     # Prior to Mountain Lion?
-    message(STATUS "@@@@ have no idea which darwin")
   endif()
 endif()
 

--- a/vm/vm/main/CMakeLists.txt
+++ b/vm/vm/main/CMakeLists.txt
@@ -1,8 +1,20 @@
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND IS_DIRECTORY "/usr/lib/c++/v1")
-  set(MOZART_GENERATOR_FLAGS "-I/usr/lib/c++/v1")
-  include_directories(/usr/lib/c++/v1)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  if(IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
+    # Mavericks
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(MOZART_GENERATOR_FLAGS
+        "-I/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
+    include_directories(/Library/Developer/CommandLineTools/usr/lib/c++/v1/)
+  elseif(IS_DIRECTORY "/usr/lib/c++/v1")
+    # Mountain Lion
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    set(MOZART_GENERATOR_FLAGS "-I/usr/lib/c++/v1")
+    include_directories(/usr/lib/c++/v1)
+  else()
+    # Prior to Mountain Lion?
+  endif()
 endif()
 
 # properties-config.cc

--- a/vm/vm/test/CMakeLists.txt
+++ b/vm/vm/test/CMakeLists.txt
@@ -10,9 +10,18 @@ if(MINGW)
          CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND IS_DIRECTORY "/usr/lib/c++/v1")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-  include_directories(/usr/lib/c++/v1)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  if(IS_DIRECTORY "/Library/Developer/CommandLineTools/usr/lib/c++/v1/")
+    # Mavericks
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    include_directories(/Library/Developer/CommandLineTools/usr/lib/c++/v1/)
+  elseif(IS_DIRECTORY "/usr/lib/c++/v1")
+    # Mountain Lion
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    include_directories(/usr/lib/c++/v1)
+  else()
+    # Prior to Mountain Lion?
+  endif()
 endif()
 
 # GTest libraries


### PR DESCRIPTION
I made some changes to the CMAKE configuration for Mozart2 to compile on Mac OS Mavericks. Most of the changes are related to changes in the C++ headers location. 

I did my best for the changes to be backward compatible but I cannot test (I do not have 10.8 anymore). User testing is highly appreciated. Only one change could affect other systems: the version of googletest is fixed to revision 662. A problem with 663 (current trunk) prevented mozart to build on MaOS.

Can anyone provide some feedback?