### PR TITLE
Update due to {Property.put print foo(width:2 depth:2)} not working.

### DIFF
--- a/vm/vm/main/modules/modsystem.hh
+++ b/vm/vm/main/modules/modsystem.hh
@@ -55,8 +55,8 @@ public:
 
       auto& stream = boolToStdErr ? std::cerr : std::cout;
       stream << repr(vm, value,
-                     boolToStdErr ? config.errorsDepth : config.errorsWidth,
-                     boolToStdErr ? config.printDepth : config.printWidth);
+                     boolToStdErr ? config.errorsDepth : config.printDepth,
+                     boolToStdErr ? config.errorsWidth : config.printWidth);
       if (boolNewLine)
         stream << std::endl;
     }


### PR DESCRIPTION
See bug: https://github.com/mozart/mozart2/issues/115
sjrd said: The error's there:
https://github.com/mozart/mozart2/blob/master/vm/vm/main/modules/modsystem.hh#L57
I messed up the order of the ? : in the arguments ^^
It should be first boolToStdErr ? config.errorsDepth : config.printDepth then boolToStdErr ? config.errorsWidth : config.printWidth.
