### PR TITLE
Fix the Clang warning by a better approach: use template specialization

### DIFF
--- a/vm/vm/main/utf-decl.hh
+++ b/vm/vm/main/utf-decl.hh
@@ -116,6 +116,10 @@ template <class C>
 inline int compareByCodePoint(const BaseLString<C>& a,
                               const BaseLString<C>& b);
 
+template <>
+inline int compareByCodePoint<char16_t>(const BaseLString<char16_t>& a,
+                                        const BaseLString<char16_t>& b);
+
 template <class C>
 inline int compareByCodePoint(const C* a, const BaseLString<C>& b) {
   return compareByCodePoint(makeLString(a), b);


### PR DESCRIPTION
- This adds some minor duplication of trivial code
  but give us a cleaner compile-time check.

Sorry, the previous approach reveals to be less than optimal: older versions of Clang do no know `-Wtautological-constant-out-of-range-compare` and warn gently about it.
Also, this seems a really good case for template specialization.

Could you just check I did it right, like declaring it in utf-decl.hh and implementing it just after the generic version in utf.hh?

https://github.com/eregon/mozart2/compare/mozart:7064aef...eregon:fix_clang_warning_tautological?expand=1&w=1 is a much more readable diff from the old master.
