### PR TITLE
Replace the boot unpickler by the real one from Pickle.oz

### DIFF
--- a/lib/main/init/Init.oz
+++ b/lib/main/init/Init.oz
@@ -336,8 +336,11 @@ define
       end
 \endif
 
-      %% Link the real OS module, which should set up a proper BURL
+      %% Link the real OS module, which should set up a proper BURL.localize and BURL.open
       {Wait {RM link(url:'x-oz://system/OS.ozf' $)}}
+
+      %% Link the real Pickle module, which should set up a proper BURL.load
+      {RM link(url:'x-oz://system/Pickle.ozf' $)}.magicBaseFromInit = Base
 
       %% Link root functor (i.e. application)
       {Wait {RM link(url:{GET 'application.url'} $)}}

--- a/lib/main/sys/Pickle.oz
+++ b/lib/main/sys/Pickle.oz
@@ -88,11 +88,16 @@ export
    WriteValueToSink
    ReadValueFromSource
 
+   MagicBaseFromInit
+
 import
    OS
    Open
+   BURL at 'x-oz://boot/URL'
 
 define
+
+   MagicBaseFromInit
 
    % HeaderMagic = [0x56 0xb4 0x8c 0x48]
 
@@ -142,7 +147,7 @@ define
       end
 
       meth read(Size ?Result ?ActualSize)
-         {OS.fread self.file Size ?Result nil ?ActualSize}
+         {self.file read(size:Size list:?Result len:?ActualSize)}
       end
    end
 
@@ -202,8 +207,10 @@ define
    end
 
    fun {LoadWithHeader URL}
-      File = {New Open.file init(url:URL flags:[read])}
-   in
+      {LoadWithHeaderFromFile {New Open.file init(url:URL flags:[read])}}
+   end
+
+   fun {LoadWithHeaderFromFile File}
       try
          Source = {New OpenSource init(File)}
          Header Value
@@ -782,4 +789,18 @@ define
       Nodes.ResultIndex
    end
 
+   fun {BURL_load URL}
+      % See Init's BootURLLoad
+      TempResult = {LoadWithHeaderFromFile {New Open.file init(name:URL flags:[read])}}.2
+   in
+      if {IsProcedure TempResult} then
+         {TempResult MagicBaseFromInit}
+      else
+         TempResult
+      end
+   end
+
+   %% Replace the boot unpickler by the real one
+   {Wait Open}
+   {BootReflection.become BURL.load BURL_load}
 end


### PR DESCRIPTION
- Fix a bug in Pickle.OpenSource.read.
- Need to {Wait Open} so we are sure Open is loaded before BURL.load is called.
