### PR TITLE
Found and fixed problem with recent GTest revisions

### DIFF
--- a/vm/vm/CMakeLists.txt
+++ b/vm/vm/CMakeLists.txt
@@ -15,7 +15,6 @@ if("${GTEST_SRC_DIR}" STREQUAL "${DEFAULT_GTEST_SRC_DIR}" AND
 
   ExternalProject_Add(gtest
     SVN_REPOSITORY http://googletest.googlecode.com/svn/trunk
-    SVN_REVISION -r "662"
     CMAKE_ARGS ${GTEST_CMAKE_ARGS}
     INSTALL_COMMAND ""
     TEST_COMMAND ""

--- a/vm/vm/main/float.hh
+++ b/vm/vm/main/float.hh
@@ -22,8 +22,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef __FLOAT_H
-#define __FLOAT_H
+#ifndef __MOZART_FLOAT_H
+#define __MOZART_FLOAT_H
 
 #include <tuple>
 #include <memory>
@@ -206,4 +206,4 @@ UnstableNode Float::tanh(VM vm) {
 
 #endif // MOZART_GENERATOR
 
-#endif // __FLOAT_H
+#endif // __MOZART_FLOAT_H


### PR DESCRIPTION
- __FLOAT_H is defined both by our vm/vm/main/float.hh
  and Clang's float.h (usually /usr/lib/clang/5.0/include/float.h).
- It might also be considered as a problem of Clang
  (other #define have weird names or start with __CLANG_).
