### PR TITLE
Revert "Replace the boot unpickler by the real one from Pickle.oz"

### DIFF
--- a/lib/main/init/Init.oz
+++ b/lib/main/init/Init.oz
@@ -339,9 +339,6 @@ define
       %% Link the real OS module, which should set up a proper BURL.localize and BURL.open
       {Wait {RM link(url:'x-oz://system/OS.ozf' $)}}
 
-      %% Link the real Pickle module, which should set up a proper BURL.load
-      {RM link(url:'x-oz://system/Pickle.ozf' $)}.magicBaseFromInit = Base
-
       %% Link root functor (i.e. application)
       {Wait {RM link(url:{GET 'application.url'} $)}}
    end

--- a/lib/main/sys/Pickle.oz
+++ b/lib/main/sys/Pickle.oz
@@ -88,16 +88,11 @@ export
    WriteValueToSink
    ReadValueFromSource
 
-   MagicBaseFromInit
-
 import
    OS
    Open
-   BURL at 'x-oz://boot/URL'
 
 define
-
-   MagicBaseFromInit
 
    % HeaderMagic = [0x56 0xb4 0x8c 0x48]
 
@@ -207,10 +202,8 @@ define
    end
 
    fun {LoadWithHeader URL}
-      {LoadWithHeaderFromFile {New Open.file init(url:URL flags:[read])}}
-   end
-
-   fun {LoadWithHeaderFromFile File}
+      File = {New Open.file init(url:URL flags:[read])}
+   in
       try
          Source = {New OpenSource init(File)}
          Header Value
@@ -789,18 +782,4 @@ define
       Nodes.ResultIndex
    end
 
-   fun {BURL_load URL}
-      % See Init's BootURLLoad
-      TempResult = {LoadWithHeaderFromFile {New Open.file init(name:URL flags:[read])}}.2
-   in
-      if {IsProcedure TempResult} then
-         {TempResult MagicBaseFromInit}
-      else
-         TempResult
-      end
-   end
-
-   %% Replace the boot unpickler by the real one
-   {Wait Open}
-   {BootReflection.become BURL.load BURL_load}
 end


### PR DESCRIPTION
- It severely impacts compilation time (and uses a lot more memory).
- This reverts most of commit 2efe0be998664ff2dffa3a119efe42f1a70bf2e5 (See #141).
- The fix in Pickle.oz and the better comment are kept.

Using the real unpickler is quite costly for now.
My measurements can be seen [here](https://gist.github.com/eregon/148999525abb5121e66f).
In summary:
- to compile Hello World: more than 10s instead of less than 1s and 1GB of RSS instead of 20MB.
- to compile testBigInt.oz: about 3 times slower (5 -> 15s, 12 -> 38s) and 4 times memory usage: 1GB instead of 256MB.

Of course, memory usage can be reduced with `--max-memory` and it does not impacts a lot the execution time but it means patching `bin/ozc`.
I am wondering if there is a not a leak, is it expected that the compiler would need to allocate more than 900MB of data structures just to compile a Hello World?
