### PR TITLE
Make SmallInt::min/max constexpr functions and no more variables

### DIFF
--- a/vm/vm/main/bigint.hh
+++ b/vm/vm/main/bigint.hh
@@ -122,7 +122,7 @@ UnstableNode BigInt::abs(RichNode self, VM vm) {
 }
 
 UnstableNode BigInt::shrink(VM vm, const std::shared_ptr<BigIntImplem>& n) {
-  if (n->compare(SmallInt::min) >= 0 && n->compare(SmallInt::max) <= 0) {
+  if (n->compare(SmallInt::min()) >= 0 && n->compare(SmallInt::max()) <= 0) {
     return SmallInt::build(vm, n->nativeintValue());
   } else {
     return BigInt::build(vm, n);

--- a/vm/vm/main/bootunpickler.cc
+++ b/vm/vm/main/bootunpickler.cc
@@ -96,7 +96,7 @@ private:
     long long intResult = std::strtoll(str.c_str(), &end, 10);
     assert(*end == '\0' && "bad integer string");
     nativeint value = (nativeint) intResult;
-    if (value == SmallInt::min || value == SmallInt::max) { // Overflow
+    if (value == SmallInt::min() || value == SmallInt::max()) { // Overflow
       return vm->newBigInt(str);
     } else {
       return build(vm, value);

--- a/vm/vm/main/modules/modfloat.hh
+++ b/vm/vm/main/modules/modfloat.hh
@@ -78,7 +78,7 @@ public:
       double err;
 
       // Simple overflow check of double -> nativeint conversion
-      if (intValue == SmallInt::min || intValue == SmallInt::max) {
+      if (intValue == SmallInt::min() || intValue == SmallInt::max()) {
         result = vm->newBigInt(floatValue);
         err = floatValue - static_cast<RichNode>(result).as<BigInt>().doubleValue();
       } else {

--- a/vm/vm/main/properties.cc
+++ b/vm/vm/main/properties.cc
@@ -146,10 +146,8 @@ void PropertyRegistry::registerPredefined(VM vm) {
 
   // Limits
 
-  registerConstantProp(vm, "limits.int.min",
-                       std::numeric_limits<nativeint>::min());
-  registerConstantProp(vm, "limits.int.max",
-                       std::numeric_limits<nativeint>::max());
+  registerConstantProp(vm, "limits.int.min", SmallInt::min());
+  registerConstantProp(vm, "limits.int.max", SmallInt::max());
   registerConstantProp(vm, "limits.bytecode.xregisters",
                        std::numeric_limits<ByteCode>::max());
 

--- a/vm/vm/main/smallint-decl.hh
+++ b/vm/vm/main/smallint-decl.hh
@@ -38,8 +38,12 @@ class SmallInt: public DataType<SmallInt>, StoredAs<nativeint>,
 public:
   static constexpr UUID uuid = "{00000000-0000-4f00-0000-000000000001}";
 
-  static constexpr nativeint min = std::numeric_limits<nativeint>::min();
-  static constexpr nativeint max = std::numeric_limits<nativeint>::max();
+  static constexpr nativeint min() {
+    return std::numeric_limits<nativeint>::min();
+  }
+  static constexpr nativeint max() {
+    return std::numeric_limits<nativeint>::max();
+  }
 
   static atom_t getTypeAtom(VM vm) {
     return vm->getAtom("int");
@@ -126,7 +130,7 @@ public:
   void printReprToStream(VM vm, std::ostream& out, int depth, int width) {
     if (value() >= 0) {
       out << value();
-    } else if (value() == min) {
+    } else if (value() == min()) {
       std::ostringstream ss;
       ss << value();
       std::string s(ss.str());

--- a/vm/vm/main/smallint.hh
+++ b/vm/vm/main/smallint.hh
@@ -78,11 +78,11 @@ int SmallInt::compare(RichNode self, VM vm, RichNode right) {
 
 UnstableNode SmallInt::opposite(VM vm) {
   // Detecting overflow - platform dependent (2's complement)
-  if (value() != min) {
+  if (value() != min()) {
     // No overflow
     return SmallInt::build(vm, -value());
   } else {
-    UnstableNode big = vm->newBigInt(min);
+    UnstableNode big = vm->newBigInt(min());
     return Numeric(big).opposite(vm);
   }
 }
@@ -172,8 +172,8 @@ bool SmallInt::testMultiplyOverflow(nativeint a, nativeint b) {
     return false;
 
   // Slow test (because of the division)
-  return (a == min) ||
-         ((b != 0) && (absa >= max / absb));
+  return (a == min()) ||
+         ((b != 0) && (absa >= max() / absb));
 }
 
 UnstableNode SmallInt::multiplyValue(VM vm, nativeint b) {
@@ -211,7 +211,7 @@ UnstableNode SmallInt::divValue(VM vm, nativeint b) {
   }
 
   // Detecting overflow
-  if ((a != min) || (b != -1)) {
+  if ((a != min()) || (b != -1)) {
     // No overflow
     return SmallInt::build(vm, a / b);
   } else {
@@ -239,7 +239,7 @@ UnstableNode SmallInt::modValue(VM vm, nativeint b) {
   nativeint a = value();
 
   // Detecting overflow
-  if ((a != min) || (b != -1)) {
+  if ((a != min()) || (b != -1)) {
     // No overflow
     return SmallInt::build(vm, a % b);
   } else {
@@ -252,11 +252,11 @@ UnstableNode SmallInt::modValue(VM vm, nativeint b) {
 UnstableNode SmallInt::abs(VM vm) {
   nativeint a = value();
   // Detecting overflow - platform dependent (2's complement)
-  if (a != min) {
+  if (a != min()) {
     // No overflow
     return SmallInt::build(vm, a >= 0 ? a : -a);
   } else {
-    UnstableNode big = vm->newBigInt(min);
+    UnstableNode big = vm->newBigInt(min());
     return Numeric(big).opposite(vm);
   }
 }

--- a/vm/vm/test/virtualstringtest.cc
+++ b/vm/vm/test/virtualstringtest.cc
@@ -57,9 +57,9 @@ protected:
                                -4,
                                -5);
 
-    testNodes[25] = SmallInt::build(vm, SmallInt::min);
+    testNodes[25] = SmallInt::build(vm, SmallInt::min());
 
-    auto s = intToString(SmallInt::min);
+    auto s = intToString(SmallInt::min());
     std::copy(s.cbegin(), s.cend(), std::back_inserter(minStr));
   }
 


### PR DESCRIPTION
- They do not seem fully supported at linking time and
  behavior differs between Clang and GCC
- Fixes compilation on OS X
