### PR TITLE
Show operands when an unification fails, so it is much easier to interpret

### DIFF
--- a/vm/vm/main/emulate.hh
+++ b/vm/vm/main/emulate.hh
@@ -287,7 +287,7 @@ private:
                     StaticArray<StableNode>& kregs,
                     bool& preempted);
 
-  void applyFail(VM vm,
+  void applyFail(VM vm, RichNode info,
                  StableNode*& abstraction,
                  ProgramCounter& PC, size_t& yregCount,
                  XRegArray* xregs,

--- a/vm/vm/main/exceptions-decl.hh
+++ b/vm/vm/main/exceptions-decl.hh
@@ -61,7 +61,7 @@ public:
   }
 
   void MOZART_NORETURN throwException(ExceptionKind kind,
-                                      StableNode* dataNode = nullptr) {
+                                      StableNode* dataNode) {
     _exceptionKind = kind;
     _dataNode = dataNode;
     rethrow();
@@ -101,6 +101,9 @@ private:
 
 inline
 void MOZART_NORETURN fail(VM vm);
+
+inline
+void MOZART_NORETURN fail(VM vm, RichNode info);
 
 inline
 void MOZART_NORETURN waitFor(VM vm, RichNode waitee);

--- a/vm/vm/main/exceptions.hh
+++ b/vm/vm/main/exceptions.hh
@@ -31,8 +31,14 @@ namespace mozart {
 
 inline
 void MOZART_NORETURN fail(VM vm) {
+  UnstableNode info = Unit::build(vm);
+  fail(vm, info);
+}
+
+inline
+void MOZART_NORETURN fail(VM vm, RichNode info) {
   vm->getGlobalExceptionMechanism().throwException(
-    ExceptionKind::ekFail);
+    ExceptionKind::ekFail, info.getStableRef(vm));
 }
 
 inline

--- a/vm/vm/main/unify.cc
+++ b/vm/vm/main/unify.cc
@@ -86,8 +86,10 @@ private:
 
 void fullUnify(VM vm, RichNode left, RichNode right) {
   StructuralDualWalk walk(vm, StructuralDualWalk::wkUnify);
-  if (!walk.run(vm, left, right))
-    fail(vm);
+  if (!walk.run(vm, left, right)) {
+    UnstableNode info = buildList(vm, buildTuple(vm, "eq", left, right));
+    fail(vm, info);
+  }
 }
 
 bool fullEquals(VM vm, RichNode left, RichNode right) {


### PR DESCRIPTION
- The only information which can be given to fail() is debug info
- It defaults to `init`, as before

With this commit, if there is at exc.debug `unit` or a Record, the stack trace will be filled and the value at `info` preserved (`unit` if not available). Other fields of the record will be ignored, should we care to copy them (the code would be much more involved at that place)?
