### PR TITLE
Refactor the BigInt entry points to use standard builders

### DIFF
--- a/vm/boostenv/main/boostenv-decl.hh
+++ b/vm/boostenv/main/boostenv-decl.hh
@@ -113,16 +113,13 @@ private:
 
 public:
   inline
-  UnstableNode newBigInt(VM vm, nativeint value);
-
-  inline
-  UnstableNode newBigInt(VM vm, double value);
-
-  inline
-  UnstableNode newBigInt(VM vm, const std::string& value);
-
-  inline
   std::shared_ptr<BigIntImplem> newBigIntImplem(VM vm, nativeint value);
+
+  inline
+  std::shared_ptr<BigIntImplem> newBigIntImplem(VM vm, double value);
+
+  inline
+  std::shared_ptr<BigIntImplem> newBigIntImplem(VM vm, const std::string& value);
 
 // Management of nodes used by asynchronous operations for feedback
 

--- a/vm/boostenv/main/boostenv.cc
+++ b/vm/boostenv/main/boostenv.cc
@@ -243,19 +243,15 @@ std::uint64_t BoostBasedVM::bytes2uint64(const std::uint8_t* bytes) {
     ((std::uint64_t) bytes[6] << 8) + ((std::uint64_t) bytes[7] << 0);
 }
 
-UnstableNode BoostBasedVM::newBigInt(VM vm, nativeint value) {
-  return BigInt::build(vm, newBigIntImplem(vm, value));
-}
-
-UnstableNode BoostBasedVM::newBigInt(VM vm, double value) {
-  return BigInt::build(vm, BoostBigInt::make_shared_ptr(value));
-}
-
-UnstableNode BoostBasedVM::newBigInt(VM vm, const std::string& value) {
-  return BigInt::build(vm, BoostBigInt::make_shared_ptr(value));
-}
-
 std::shared_ptr<BigIntImplem> BoostBasedVM::newBigIntImplem(VM vm, nativeint value) {
+  return BoostBigInt::make_shared_ptr(value);
+}
+
+std::shared_ptr<BigIntImplem> BoostBasedVM::newBigIntImplem(VM vm, double value) {
+  return BoostBigInt::make_shared_ptr(value);
+}
+
+std::shared_ptr<BigIntImplem> BoostBasedVM::newBigIntImplem(VM vm, const std::string& value) {
   return BoostBigInt::make_shared_ptr(value);
 }
 

--- a/vm/boostenv/main/boostenvbigint-decl.hh
+++ b/vm/boostenv/main/boostenvbigint-decl.hh
@@ -92,7 +92,7 @@ public:
   void printReprToStream(VM vm, std::ostream& out, int depth, int width);
 
 public:
-  template<class T>
+  template <class T>
   static std::shared_ptr<BigIntImplem> make_shared_ptr(const T& value) {
     return std::static_pointer_cast<BigIntImplem>(std::make_shared<BoostBigInt>(value));
   }

--- a/vm/vm/main/bigint-decl.hh
+++ b/vm/vm/main/bigint-decl.hh
@@ -42,6 +42,10 @@ public:
     return vm->getAtom("int");
   }
 
+  template <class T>
+  BigInt(VM vm, T value):
+    _value(vm->getEnvironment().newBigIntImplem(vm, value)) {}
+
   BigInt(VM vm, const std::shared_ptr<BigIntImplem>& p): _value(p) {}
 
   BigInt(VM vm, GR gr, BigInt& from): _value(std::move(from._value)) {}

--- a/vm/vm/main/bigint.hh
+++ b/vm/vm/main/bigint.hh
@@ -100,7 +100,7 @@ UnstableNode BigInt::div(VM vm, RichNode right) {
     if (divisor == 0) {
       raiseKernelError(vm, "Integer division: Division by zero");
     }
-    b = vm->newBigIntImplem(divisor);
+    b = vm->getEnvironment().newBigIntImplem(vm, divisor);
   } else if (right.is<BigInt>()) {
     b = right.as<BigInt>().value();
   } else {
@@ -134,7 +134,7 @@ std::shared_ptr<BigIntImplem> BigInt::coerce(VM vm, RichNode value) {
 
   nativeint smallInt;
   if (matches(vm, value, capture(smallInt))) {
-    return vm->newBigIntImplem(smallInt);
+    return vm->getEnvironment().newBigIntImplem(vm, smallInt);
   } else if (value.is<BigInt>()) {
     return value.as<BigInt>().value();
   } else {

--- a/vm/vm/main/bootunpickler.cc
+++ b/vm/vm/main/bootunpickler.cc
@@ -99,9 +99,9 @@ private:
     nativeint value = (nativeint) intResult;
     if ((value == SmallInt::min() || value == SmallInt::max()) &&
         errno == ERANGE) { // Overflow
-      return vm->newBigInt(str);
+      return BigInt::build(vm, str);
     } else {
-      return build(vm, value);
+      return SmallInt::build(vm, value);
     }
   }
 

--- a/vm/vm/main/corebuilders.hh
+++ b/vm/vm/main/corebuilders.hh
@@ -68,7 +68,7 @@ UnstableNode build(VM vm, internal::int64IfDifferentFromNativeInt value) {
   } else {
     std::ostringstream ss;
     ss << value;
-    return vm->newBigInt(ss.str());
+    return BigInt::build(vm, ss.str());
   }
 }
 

--- a/vm/vm/main/modules/modfloat.hh
+++ b/vm/vm/main/modules/modfloat.hh
@@ -80,7 +80,7 @@ public:
       double err;
 
       if ((intValue == SmallInt::min() || intValue == SmallInt::max()) &&
-          Comparable(big = vm->newBigInt(floatValue)).compare(vm, result) != 0) {
+          Comparable(big = BigInt::build(vm, floatValue)).compare(vm, result) != 0) {
         // Overflow
         result = std::move(big);
         err = floatValue - RichNode(result).as<BigInt>().doubleValue();

--- a/vm/vm/main/smallint.hh
+++ b/vm/vm/main/smallint.hh
@@ -82,7 +82,7 @@ UnstableNode SmallInt::opposite(VM vm) {
     // No overflow
     return SmallInt::build(vm, -value());
   } else {
-    UnstableNode big = vm->newBigInt(min());
+    UnstableNode big = BigInt::build(vm, min());
     return Numeric(big).opposite(vm);
   }
 }
@@ -94,7 +94,7 @@ UnstableNode SmallInt::add(VM vm, RichNode right) {
   if (matches(vm, right, capture(smallInt))) {
     return add(vm, smallInt);
   } else if (right.is<BigInt>()) {
-    UnstableNode big = vm->newBigInt(value());
+    UnstableNode big = BigInt::build(vm, value());
     return Numeric(big).add(vm, right);
   } else {
     raiseTypeError(vm, "Integer", right);
@@ -110,7 +110,7 @@ UnstableNode SmallInt::add(VM vm, nativeint b) {
     // No overflow
     return SmallInt::build(vm, c);
   } else {
-    UnstableNode left = vm->newBigInt(a);
+    UnstableNode left = BigInt::build(vm, a);
     UnstableNode right = SmallInt::build(vm, b);
     return Numeric(left).add(vm, right);
   }
@@ -123,7 +123,7 @@ UnstableNode SmallInt::subtract(VM vm, RichNode right) {
   if (matches(vm, right, capture(smallInt))) {
     return subtractValue(vm, smallInt);
   } else if (right.is<BigInt>()) {
-    UnstableNode big = vm->newBigInt(value());
+    UnstableNode big = BigInt::build(vm, value());
     return Numeric(big).subtract(vm, right);
   } else {
     raiseTypeError(vm, "Integer", right);
@@ -139,7 +139,7 @@ UnstableNode SmallInt::subtractValue(VM vm, nativeint b) {
     // No overflow
     return SmallInt::build(vm, c);
   } else {
-    UnstableNode left = vm->newBigInt(a);
+    UnstableNode left = BigInt::build(vm, a);
     UnstableNode right = SmallInt::build(vm, b);
     return Numeric(left).subtract(vm, right);
   }
@@ -152,7 +152,7 @@ UnstableNode SmallInt::multiply(VM vm, RichNode right) {
   if (matches(vm, right, capture(smallInt))) {
     return multiplyValue(vm, smallInt);
   } else if (right.is<BigInt>()) {
-    UnstableNode big = vm->newBigInt(value());
+    UnstableNode big = BigInt::build(vm, value());
     return Numeric(big).multiply(vm, right);
   } else {
     raiseTypeError(vm, "Integer", right);
@@ -184,7 +184,7 @@ UnstableNode SmallInt::multiplyValue(VM vm, nativeint b) {
     // No overflow
     return SmallInt::build(vm, a * b);
   } else {
-    UnstableNode left = vm->newBigInt(a);
+    UnstableNode left = BigInt::build(vm, a);
     UnstableNode right = SmallInt::build(vm, b);
     return Numeric(left).multiply(vm, right);
   }
@@ -197,7 +197,7 @@ UnstableNode SmallInt::div(VM vm, RichNode right) {
   if (matches(vm, right, capture(smallInt))) {
     return divValue(vm, smallInt);
   } else if (right.is<BigInt>()) {
-    UnstableNode big = vm->newBigInt(value());
+    UnstableNode big = BigInt::build(vm, value());
     return Numeric(big).div(vm, right);
   } else {
     raiseTypeError(vm, "Integer", right);
@@ -215,7 +215,7 @@ UnstableNode SmallInt::divValue(VM vm, nativeint b) {
     // No overflow
     return SmallInt::build(vm, a / b);
   } else {
-    UnstableNode left = vm->newBigInt(a);
+    UnstableNode left = BigInt::build(vm, a);
     UnstableNode right = SmallInt::build(vm, b);
     return Numeric(left).div(vm, right);
   }
@@ -228,7 +228,7 @@ UnstableNode SmallInt::mod(VM vm, RichNode right) {
   if (matches(vm, right, capture(smallInt))) {
     return modValue(vm, smallInt);
   } else if (right.is<BigInt>()) {
-    UnstableNode big = vm->newBigInt(value());
+    UnstableNode big = BigInt::build(vm, value());
     return Numeric(big).mod(vm, right);
   } else {
     raiseTypeError(vm, "Integer", right);
@@ -243,7 +243,7 @@ UnstableNode SmallInt::modValue(VM vm, nativeint b) {
     // No overflow
     return SmallInt::build(vm, a % b);
   } else {
-    UnstableNode left = vm->newBigInt(a);
+    UnstableNode left = BigInt::build(vm, a);
     UnstableNode right = SmallInt::build(vm, b);
     return Numeric(left).mod(vm, right);
   }
@@ -256,7 +256,7 @@ UnstableNode SmallInt::abs(VM vm) {
     // No overflow
     return SmallInt::build(vm, a >= 0 ? a : -a);
   } else {
-    UnstableNode big = vm->newBigInt(min());
+    UnstableNode big = BigInt::build(vm, min());
     return Numeric(big).opposite(vm);
   }
 }

--- a/vm/vm/main/vm-decl.hh
+++ b/vm/vm/main/vm-decl.hh
@@ -103,16 +103,13 @@ public:
   virtual UUID genUUID() = 0;
 
   inline
-  virtual UnstableNode newBigInt(VM vm, nativeint value);
-
-  inline
-  virtual UnstableNode newBigInt(VM vm, double value);
-
-  inline
-  virtual UnstableNode newBigInt(VM vm, const std::string& value);
-
-  inline
   virtual std::shared_ptr<BigIntImplem> newBigIntImplem(VM vm, nativeint value);
+
+  inline
+  virtual std::shared_ptr<BigIntImplem> newBigIntImplem(VM vm, double value);
+
+  inline
+  virtual std::shared_ptr<BigIntImplem> newBigIntImplem(VM vm, const std::string& value);
 
   virtual void gCollect(GC gc) {
   }
@@ -256,15 +253,6 @@ public:
   void setAlarm(std::int64_t delay, StableNode* wakeable);
 
 public:
-  inline
-  UnstableNode newBigInt(nativeint value);
-
-  inline
-  UnstableNode newBigInt(double value);
-
-  inline
-  UnstableNode newBigInt(const std::string& value);
-
   inline
   std::shared_ptr<BigIntImplem> newBigIntImplem(nativeint value);
 

--- a/vm/vm/main/vm.hh
+++ b/vm/vm/main/vm.hh
@@ -47,19 +47,15 @@ void BuiltinModule::initModule(VM vm, T&& module) {
 // VirtualMachine //
 ////////////////////
 
-UnstableNode VirtualMachineEnvironment::newBigInt(VM vm, nativeint value) {
-  raiseError(vm, "Overflow! BigInt unsupported in the default VM environment without implementation");
-}
-
-UnstableNode VirtualMachineEnvironment::newBigInt(VM vm, double value) {
-  raiseError(vm, "Overflow! BigInt unsupported in the default VM environment without implementation");
-}
-
-UnstableNode VirtualMachineEnvironment::newBigInt(VM vm, const std::string& value) {
-  raiseError(vm, "Overflow! BigInt unsupported in the default VM environment without implementation");
-}
-
 std::shared_ptr<BigIntImplem> VirtualMachineEnvironment::newBigIntImplem(VM vm, nativeint value) {
+  raiseError(vm, "Overflow! BigInt unsupported in the default VM environment without implementation");
+}
+
+std::shared_ptr<BigIntImplem> VirtualMachineEnvironment::newBigIntImplem(VM vm, double value) {
+  raiseError(vm, "Overflow! BigInt unsupported in the default VM environment without implementation");
+}
+
+std::shared_ptr<BigIntImplem> VirtualMachineEnvironment::newBigIntImplem(VM vm, const std::string& value) {
   raiseError(vm, "Overflow! BigInt unsupported in the default VM environment without implementation");
 }
 
@@ -158,22 +154,6 @@ void VirtualMachine::setAlarm(std::int64_t delay, StableNode* wakeable) {
     ++iter;
 
   _alarms.insert_before_new(this, iter, expiration, wakeable);
-}
-
-UnstableNode VirtualMachine::newBigInt(nativeint value) {
-  return environment.newBigInt(this, value);
-}
-
-UnstableNode VirtualMachine::newBigInt(double value) {
-  return environment.newBigInt(this, value);
-}
-
-UnstableNode VirtualMachine::newBigInt(const std::string& value) {
-  return environment.newBigInt(this, value);
-}
-
-std::shared_ptr<BigIntImplem> VirtualMachine::newBigIntImplem(nativeint value) {
-  return environment.newBigIntImplem(this, value);
 }
 
 template <typename T>


### PR DESCRIPTION
... and reduce the number of BigInt-specific methods in VM/VMEnv.
Also fixes a missing overflow check on 32-bits.
