### PR TITLE
Fix (wrong) clang 3.4 warning (happens on Mavericks)

### DIFF
--- a/vm/vm/main/lstring-decl.hh
+++ b/vm/vm/main/lstring-decl.hh
@@ -163,8 +163,14 @@ struct LString : BaseLString<C> {
   inline LString(VM vm, nativeint length, const F& initializer);
 
   // Only LString can be safely sliced.
-  inline constexpr const LString slice(nativeint from, nativeint to) const;
-  inline constexpr const LString slice(nativeint from) const;
+  inline constexpr const LString slice(nativeint from, nativeint to) const {
+    return this->isErrorOrEmpty()
+        ? LString<C>(this->error)
+        : LString<C>(this->string + from, to - from);
+  }
+  inline constexpr const LString slice(nativeint from) const {
+    return slice(from, this->length);
+  }
 
   template <nativeint n>
   static constexpr const LString<C>

--- a/vm/vm/main/lstring.hh
+++ b/vm/vm/main/lstring.hh
@@ -128,19 +128,6 @@ LString<C>::LString(VM vm, nativeint length, const F& initializer) {
   this->length = length;
 }
 
-template <class C>
-constexpr const LString<C> LString<C>::slice(nativeint from) const {
-  return slice(from, this->length);
-}
-
-template <class C>
-constexpr const LString<C> LString<C>::slice(nativeint from,
-                                             nativeint to) const {
-  return this->isErrorOrEmpty()
-      ? LString<C>(this->error)
-      : LString<C>(this->string + from, to - from);
-}
-
 }
 
 // ContainedLString ------------------------------------------------------------


### PR DESCRIPTION
I just update to OS X 10.9 Mavericks.
Apart from that warning, it cleanly builds, but I had to change a couple things:
- Reinstall the command-line tools with `xcode-select --install` (Homebrew asks for it whenever you use it)
- Reinstall boost with C++11 support (it was producing warnings about incompatible integral types): `brew install boost --c++11`.
- In the CMake configuration, the path to C++11 headers changed from `/usr/lib/c++/v1` to `/Library/Developer/CommandLineTools/usr/lib/c++/v1`. (Without the command line tools, they are available in `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/c++/v1` and other very long paths which are not supposed to be used). This is actually needed only for the custom LLVM/Clang which does not know the right system paths. The system clang knows them and needs no hint.
  I shall update the README in #124.

See the commit description for details about the warning.

@sjrd @sjmackenzie Could you merge this soon?
