### PR TITLE
Rename Boot_Port.sendReceive to sendRecv to match real name in Port

### DIFF
--- a/lib/main/base/Base.oz
+++ b/lib/main/base/Base.oz
@@ -133,7 +133,7 @@ prepare
    IsPort   = Boot_Port.is
    NewPort  = Boot_Port.new
    Send     = Boot_Port.send
-   SendRecv = Boot_Port.sendReceive
+   SendRecv = Boot_Port.sendRecv
 
    %%
    %% Atom

--- a/vm/vm/main/modules/modport.hh
+++ b/vm/vm/main/modules/modport.hh
@@ -70,7 +70,7 @@ public:
 
   class SendReceive: public Builtin<SendReceive> {
   public:
-    SendReceive(): Builtin("sendReceive") {}
+    SendReceive(): Builtin("sendRecv") {}
 
     static void call(VM vm, In port, In value, Out reply) {
       reply = PortLike(port).sendReceive(vm, value);


### PR DESCRIPTION
- Port.sendRecv was shown as "Port.sendReceive" in Browser,
  which does not exist and should be "Port.sendRecv".

This requires to recompile Base.oz and maybe a couple others.
Tested with a clean build and works as expected.
