### PR TITLE
Make the parent VM always monitor its child VMs

### DIFF
--- a/boosthost/emulator/emulator.cc
+++ b/boosthost/emulator/emulator.cc
@@ -417,7 +417,6 @@ int main(int argc, char** argv) {
     return true;
   });
 
-  std::unique_ptr<std::string> app(new std::string(appURL));
-  boostEnv.addVM(std::move(app), true, vmOptions);
+  boostEnv.addInitialVM(appURL, vmOptions);
   return boostEnv.runIO();
 }

--- a/vm/boostenv/main/boostenv-decl.hh
+++ b/vm/boostenv/main/boostenv-decl.hh
@@ -68,8 +68,15 @@ public:
 
 public:
   inline
-  VMIdentifier addVM(std::unique_ptr<std::string>&& app, bool isURL,
+  VMIdentifier addVM(VMIdentifier parent,
+                     std::unique_ptr<std::string>&& app, bool isURL,
                      VirtualMachineOptions options);
+
+  VMIdentifier addInitialVM(const std::string& appURL,
+                            VirtualMachineOptions options) {
+    std::unique_ptr<std::string> app(new std::string(appURL));
+    return addVM(InitialVMIdentifier, std::move(app), true, options);
+  }
 
   inline
   VMIdentifier checkValidIdentifier(VM vm, RichNode identifier);

--- a/vm/boostenv/main/boostenv.hh
+++ b/vm/boostenv/main/boostenv.hh
@@ -123,10 +123,11 @@ BoostEnvironment::BoostEnvironment(const VMStarter& vmStarter) :
 #endif
 }
 
-VMIdentifier BoostEnvironment::addVM(std::unique_ptr<std::string>&& app, bool isURL,
+VMIdentifier BoostEnvironment::addVM(VMIdentifier parent,
+                                     std::unique_ptr<std::string>&& app, bool isURL,
                                      VirtualMachineOptions options) {
   std::lock_guard<std::mutex> lock(_vmsMutex);
-  _vms.emplace_front(*this, _nextVMIdentifier++, options, std::move(app), isURL);
+  _vms.emplace_front(*this, parent, _nextVMIdentifier++, options, std::move(app), isURL);
   return _vms.front().identifier;
 }
 

--- a/vm/boostenv/main/boostvm-decl.hh
+++ b/vm/boostenv/main/boostvm-decl.hh
@@ -47,7 +47,7 @@ class BoostEnvironment;
 
 class BoostVM : VirtualMachine {
 public:
-  BoostVM(BoostEnvironment& environment,
+  BoostVM(BoostEnvironment& environment, VMIdentifier parent,
           VMIdentifier identifier,
           VirtualMachineOptions options,
           std::unique_ptr<std::string>&& app, bool isURL);

--- a/vm/boostenv/main/boostvm.cc
+++ b/vm/boostenv/main/boostvm.cc
@@ -35,6 +35,7 @@ namespace mozart { namespace boostenv {
 /////////////
 
 BoostVM::BoostVM(BoostEnvironment& environment,
+                 VMIdentifier parent,
                  VMIdentifier identifier,
                  VirtualMachineOptions options,
                  std::unique_ptr<std::string>&& app, bool isURL) :
@@ -51,6 +52,9 @@ BoostVM::BoostVM(BoostEnvironment& environment,
 
   // Make sure the IO thread will wait for us
   _work = new boost::asio::io_service::work(environment.io_service);
+
+  if (identifier != parent)
+    addMonitor(parent);
 
   builtins::biref::registerBuiltinModOS(vm);
   builtins::biref::registerBuiltinModVM(vm);

--- a/vm/boostenv/main/modvm.hh
+++ b/vm/boostenv/main/modvm.hh
@@ -73,6 +73,7 @@ public:
     static void call(VM vm, In app, Out result) {
       using namespace mozart::patternmatching;
 
+      VMIdentifier parent = BoostVM::forVM(vm).identifier;
       atom_t appURL;
       std::unique_ptr<std::string> appStr(new std::string());
       bool isURL = matches(vm, app, capture(appURL));
@@ -92,7 +93,8 @@ public:
       options.minimalHeapSize = config.minimalHeapSize;
       options.maximalHeapSize = config.maximalHeapSize;
 
-      VMIdentifier newVM = BoostEnvironment::forVM(vm).addVM(std::move(appStr), isURL, options);
+      VMIdentifier newVM = BoostEnvironment::forVM(vm).addVM(
+        parent, std::move(appStr), isURL, options);
       result = build(vm, newVM);
     }
   };


### PR DESCRIPTION
- So at least the parent get detailed information about the termination.
- This suggests to care more about termination of created VMs.
- Adapt and improve the tests.

This is the one big thing which was missing for the multi-VM PR.
