### PR TITLE
Stop exporting the not implemented CompressedFile in Open.oz

### DIFF
--- a/lib/main/op/Open.oz
+++ b/lib/main/op/Open.oz
@@ -180,7 +180,7 @@ in
         )
 
       Error(registerFormatter)
-      ZlibIO(compressedFile:CompressedFile) at 'x-oz://system/ZlibIO.ozf'
+      % ZlibIO(compressedFile:CompressedFile) at 'x-oz://system/ZlibIO.ozf' % Not yet implemented in Mozart 2
 
       Resolve(open)
 
@@ -190,7 +190,7 @@ in
       socket: Socket
       pipe:   Pipe
       html:   Html
-      compressedFile: CompressedFile
+      % compressedFile: CompressedFile % See above
 
    define
 


### PR DESCRIPTION
- The ZlibIO boot module is not yet implemented.
- A few scripts (Pickler.oz, Executor.oz) check
  {HasFeature Open compressedFile},
  so now they should behave properly as it is not defined.

May I merge this? :smile: 
