### PR TITLE
Load Pickle in the VM module in VM.getPort and VM.new.

### DIFF
--- a/vm/boostenv/lib/VM.oz
+++ b/vm/boostenv/lib/VM.oz
@@ -53,7 +53,10 @@ define
          {Boot_VM.new App}
       end
    end
-   GetPort = Boot_VM.getPort
+   fun {GetPort VMIdent}
+      {Wait Pickle} % we need it for Send on VM ports
+      {Boot_VM.getPort VMIdent}
+   end
    IdentForPort = Boot_VM.identForPort
    GetStream = Boot_VM.getStream
    CloseStream = Boot_VM.closeStream
@@ -61,6 +64,4 @@ define
    Kill = Boot_VM.kill
    Monitor = Boot_VM.monitor
 
-   % Let's load Pickle since we need it for VM Ports
-   {Wait Pickle}
 end


### PR DESCRIPTION
- So it is only loaded when we are about to need it
  (we cannot easily load it in Send).
- If someone uses a reference to VM.getPort, then passing it around
  carries the dependency on Pickle, which is necessary.
- Messages sent to monitor streams are fine as they do not need Pickle.
