### PR TITLE
Add Boot_Time.getMonotonicTime for benchmarking purpose

### DIFF
--- a/vm/vm/main/modules/modtime.hh
+++ b/vm/vm/main/modules/modtime.hh
@@ -25,6 +25,8 @@
 #ifndef MOZART_MODTIME_H
 #define MOZART_MODTIME_H
 
+#include <chrono>
+
 #include "../mozartcore.hh"
 
 #ifndef MOZART_GENERATOR
@@ -63,6 +65,18 @@ public:
 
     static void call(VM vm, Out result) {
       result = build(vm, vm->getReferenceTime());
+    }
+  };
+
+  class GetMonotonicTime: public Builtin<GetMonotonicTime> {
+  public:
+    GetMonotonicTime(): Builtin("getMonotonicTime") {}
+
+    static void call(VM vm, Out result) {
+      using namespace std::chrono;
+      auto now = steady_clock::now();
+      nanoseconds dur = duration_cast<nanoseconds>(now.time_since_epoch());
+      result = build(vm, dur.count());
     }
   };
 };


### PR DESCRIPTION
- The unit is the nanosecond and it uses a monotonic clock,
  C++'s steady_clock.
- It is slightly expensive on 32-bit as it will return a BigInt.

@sjrd What do you think?
Mozart 1 seems to have only 1 second precision which is really not practical for benchmarking.
In Mozart 2 I used Boot_Time.getReferenceTime but it uses `gettimeofday(2)` which is not monotonic and has millisecond precision.
I wish C++ had some wrapper around a CPU time clock (user+system time) but it does not.
So a monotonic clock seems the best we can get with reasonable effort. What about the unit? Most platforms will have nanosecond precision, but actual resolution is usually lower. Millisecond might be too limiting and microsecond might seem arbitrary. Microsecond is definitely useful (I could profile some parts of `{Pickle.pack 1}` with it).
The issue about bigints on 32-bits is not easy to solve as even microsecond precision requires integers of at least 45 bits (http://en.cppreference.com/w/cpp/chrono/duration).
I add it in Boot_Time as I am not sure it should part of the public Time (or another module) interface just yet.
