### PR TITLE
Make `ozc -g` and stack traces work

### DIFF
--- a/lib/compiler/NewAssembler.oz
+++ b/lib/compiler/NewAssembler.oz
@@ -151,6 +151,12 @@ define
       arrayFillNewVars: 6
 
       inlineEqualsInteger: 0x80
+
+      debugEntry: 0xa0
+      debugExit: 0xa1
+      localVarname: 0xa2
+      globalVarname: 0xa3
+      clearY: 0xa4
    )
 
    fun {GetInstrSize Instr}
@@ -281,6 +287,11 @@ define
       [] arrayFillNewVar(S=y(_)) then arrayFillNewVarY(S)
 
       [] custom(...) then Instr
+      [] debugEntry(Filename Line Column Kind) then debugEntry(k(Filename) Line Column k(Kind))
+      [] debugExit(Filename Line Column Kind) then debugExit(k(Filename) Line Column k(Kind))
+      [] localVarname(Name) then localVarname(k(Name))
+      [] globalVarname(Name) then globalVarname(k(Name))
+      [] clear(R=y(_)) then clearY(R)
 
       else
          if {Not {HasFeature OpCodeTable {Label Instr}}} then

--- a/platform-test/CMakeLists.txt
+++ b/platform-test/CMakeLists.txt
@@ -28,6 +28,16 @@ file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bench")
 foreach(FUNCTOR ${BENCH_FUNCTORS})
   set(BENCH_FUNCTORS_OZ ${BENCH_FUNCTORS_OZ} "/bench/${FUNCTOR}")
 endforeach()
+
+# debug folder
+set(DEBUG_FUNCTORS
+    "stacktrace_line_num.oz"
+)
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/debug")
+foreach(FUNCTOR ${DEBUG_FUNCTORS})
+  set(DEBUG_FUNCTORS_OZ ${DEBUG_FUNCTORS_OZ} "/debug/${FUNCTOR}")
+endforeach()
+
 # dp folder
 set(DP_FUNCTORS
     #"basicfault.oz"
@@ -151,6 +161,21 @@ foreach(FUNCTOR ${TEST_FUNCTORS_WITH_LIB})
         COMMENT "(compiling platform-test) ${FUNCTOR_OZF}"
         VERBATIM)
 endforeach()
+foreach(FUNCTOR ${DEBUG_FUNCTORS_OZ})
+    set(FUNCTOR_OZ "${CMAKE_CURRENT_SOURCE_DIR}${FUNCTOR}")
+    set(FUNCTOR_OZF "${CMAKE_CURRENT_BINARY_DIR}${FUNCTOR}f")
+    set(TEST_FUNCTORS_OZF ${TEST_FUNCTORS_OZF} "${FUNCTOR_OZF}")
+    add_custom_command(
+        OUTPUT "${FUNCTOR_OZF}"
+        COMMAND ozemulator
+            --home "${MOZART_BUILD_DIR}"
+            x-oz://system/Compile.ozf
+            -g -c "${FUNCTOR_OZ}"
+            -o "${FUNCTOR_OZF}"
+        DEPENDS library "${FUNCTOR_OZ}"
+        COMMENT "(compiling platform-test) ${FUNCTOR_OZF}"
+        VERBATIM)
+endforeach()
 set(RUNNER "/simple_runner.oz")
 set(RUNNER_OZ "${CMAKE_CURRENT_SOURCE_DIR}${RUNNER}")
 set(RUNNER_OZF "${CMAKE_CURRENT_BINARY_DIR}${RUNNER}f")
@@ -174,7 +199,7 @@ if(BUILD_TESTING)
     add_test("vmtest" "${CMAKE_CURRENT_BINARY_DIR}/../vm/vm/test/vmtest")
     # running tests in platform-test
     set(OZEMULATOR "${CMAKE_CURRENT_BINARY_DIR}/../boosthost/emulator/ozemulator")
-    foreach(FUNCTOR ${TEST_FUNCTORS})
+    foreach(FUNCTOR ${TEST_FUNCTORS} ${DEBUG_FUNCTORS_OZ})
         set(FUNCTOR_OZF "${CMAKE_CURRENT_BINARY_DIR}${FUNCTOR}f")
         set(TEST_FUNCTORS_OZF ${TEST_FUNCTORS_OZF} "${FUNCTOR_OZF}")
         add_test(${FUNCTOR} ${OZEMULATOR} --home "${MOZART_BUILD_DIR}" "${RUNNER_OZF}" "${FUNCTOR_OZF}")

--- a/platform-test/debug/stacktrace_line_num.oz
+++ b/platform-test/debug/stacktrace_line_num.oz
@@ -1,0 +1,52 @@
+%%%
+%%% Authors:
+%%%   kennytm
+%%%
+%%% Copyright:
+%%%   Kenny Chan, 2014
+%%%
+%%% Last change:
+%%%   $Date$ by $Author$
+%%%   $Revision$
+%%%
+%%% This file is part of Mozart, an implementation
+%%% of Oz 3
+%%%    http://www.mozart-oz.org
+%%%
+%%% See the file "LICENSE" or
+%%%    http://www.mozart-oz.org/LICENSE.html
+%%% for information on usage and redistribution
+%%% of this file, and for a DISCLAIMER OF ALL
+%%% WARRANTIES.
+%%%
+
+functor
+export
+    Return
+define
+    EnsureFailureLineNumber = 29
+    proc {EnsureFailure}
+        2 + 2 = 5
+    end
+
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    fun {CreateTestCase P LineNumber Key}
+        Key(
+            proc {$}
+                try
+                    {P}
+                catch E then
+                    Stack = E.debug.stack
+                in
+                    Stack.1.line = LineNumber
+                end
+            end
+            keys: [Key stacktraceLineNum]
+        )
+    end
+    Return = stacktraceLineNum([
+        {CreateTestCase EnsureFailure EnsureFailureLineNumber simpleFunctionCall}
+    ])
+end
+

--- a/vm/vm/main/opcodes.hh
+++ b/vm/vm/main/opcodes.hh
@@ -198,6 +198,12 @@ const OpCode OpInlineMinus1 = 0x84;
 
 const OpCode OpInlineGetClass = 0x90;
 
+const OpCode OpDebugEntry = 0xa0;
+const OpCode OpDebugExit = 0xa1;
+const OpCode OpLocalVarname = 0xa2;
+const OpCode OpGlobalVarname = 0xa3;
+const OpCode OpClearY = 0xa4;
+
 }
 
 #endif // MOZART_OPCODES_H


### PR DESCRIPTION
The sole purpose of this commit is to make `ozc -g` stop crashing and generates line number information that can be recognized in a stack trace. 

The changes here are:
1. Defined 5 opcodes emitted when `ozc -g` is used.
2. Update the current line number when we encounter the `debugEntry` and `debugExit` opcodes. The other three are currently no-op.
3. The line number info will be stored into each StackEntry (which is responsible for most changes in emulate.cc)
4. Added a test case to ensure the line number reported in the exception is correct. Since this test case requires the `-g` flag, it is compiled separately unlike its cousins.

Known issues:
1. Using `-g` with list comprehension still crashes the compiler as it requires changes in Unnester.oz beyond my knowledge.
2. Exceptions raised from unification failure will yield wrong line number because the `debugEntry` instruction is not generated for this statement. 
3. Doc/Instr mentions "Neither of ..., localVarname or globalVarname may ever be executed by the emulator." but currently `localVarname` and `globalVarname` are generated as opcodes. I don't see how these can be attached to DebugData instead as it is immutable.
