### PR TITLE
Prefer boost::mutex to std::mutex as they are not implemented in MinGW

### DIFF
--- a/vm/boostenv/main/boostenv-decl.hh
+++ b/vm/boostenv/main/boostenv-decl.hh
@@ -31,7 +31,6 @@
 #include <cstdio>
 #include <cerrno>
 #include <forward_list>
-#include <mutex>
 
 #include <boost/thread.hpp>
 
@@ -184,10 +183,10 @@ public:
 // VMs
 private:
   std::forward_list<BoostVM> _vms;
-  std::mutex _vmsMutex;
+  boost::mutex _vmsMutex;
   std::atomic_int _nextVMIdentifier;
   std::atomic_int _exitCode;
-  std::mutex _gcMutex;
+  boost::mutex _gcMutex;
 
 // Bootstrap
 private:
@@ -197,7 +196,7 @@ public:
 
 // Unsafe process-wide operations
 private:
-  std::mutex _environmentVariablesMutex;
+  boost::mutex _environmentVariablesMutex;
 
 // ASIO service
 public:

--- a/vm/boostenv/main/boostvm-decl.hh
+++ b/vm/boostenv/main/boostvm-decl.hh
@@ -28,7 +28,6 @@
 #include <mozart.hh>
 
 #include <atomic>
-#include <mutex>
 
 #include <boost/thread.hpp>
 
@@ -172,7 +171,7 @@ private:
 // Monitors
 private:
   std::vector<VMIdentifier> _monitors;
-  std::mutex _monitorsMutex;
+  boost::mutex _monitorsMutex;
 
 // Termination
 private:

--- a/vm/boostenv/main/boostvm.cc
+++ b/vm/boostenv/main/boostvm.cc
@@ -293,12 +293,12 @@ UnstableNode BoostVM::buildTerminationRecord(VMIdentifier deadVM, const std::str
 }
 
 void BoostVM::addMonitor(VMIdentifier monitor) {
-  boost::lock_guard<std::mutex> lock(_monitorsMutex);
+  boost::lock_guard<boost::mutex> lock(_monitorsMutex);
   _monitors.push_back(monitor);
 }
 
 void BoostVM::notifyMonitors() {
-  std::lock_guard<std::mutex> lock(_monitorsMutex);
+  boost::lock_guard<boost::mutex> lock(_monitorsMutex);
   VMIdentifier deadVM = this->identifier;
   std::string reason = this->_terminationReason;
   for (VMIdentifier identifier : _monitors) {


### PR DESCRIPTION
- We are in 2014 and it is C++11, sigh.
- Also fixes a mismatch.
