### PR TITLE
Prevent the preemption timer to run when termination is requested

### DIFF
--- a/vm/boostenv/main/boostvm.cc
+++ b/vm/boostenv/main/boostvm.cc
@@ -164,7 +164,8 @@ void BoostVM::run() {
 }
 
 void BoostVM::onPreemptionTimerExpire(const boost::system::error_code& error) {
-  if (error != boost::asio::error::operation_aborted) {
+  if (error != boost::asio::error::operation_aborted &&
+      !_terminationRequested) {
     // Preemption
     vm->setReferenceTime(env.getReferenceTime());
     vm->requestPreempt();


### PR DESCRIPTION
- The call to `deadline_timer.cancel()` might not do anything if the timer was about to expire (and the callback is then executed "normally").
- Detected thanks to the debug build.
