### PR TITLE
Remove the need for sbt during 'make install'

### DIFF
--- a/bootcompiler/CMakeLists.txt
+++ b/bootcompiler/CMakeLists.txt
@@ -10,12 +10,15 @@ set(SBT_JAVA_OPTS
 set(SBT "${Java_JAVA_EXECUTABLE}" ${SBT_JAVA_OPTS} -Dfile.encoding=UTF-8
   -jar "${CMAKE_CURRENT_SOURCE_DIR}/sbt-launch.jar")
 
-add_custom_target(bootcompiler
-  ALL
+file(GLOB_RECURSE bootcompiler_sources src/*)
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/bootcompiler.jar"
   COMMAND ${SBT} one-jar
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+  COMMAND ${CMAKE_COMMAND} -E copy
     "${CMAKE_CURRENT_SOURCE_DIR}/target/scala-2.9.1/bootcompiler_2.9.1-2.0-SNAPSHOT-one-jar.jar"
     "${CMAKE_CURRENT_BINARY_DIR}/bootcompiler.jar"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS "sbt-launch.jar" "build.sbt" "project/plugins.sbt" ${bootcompiler_sources}
   COMMENT "Building the bootcompiler"
   VERBATIM)
+
+add_custom_target(bootcompiler DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/bootcompiler.jar")


### PR DESCRIPTION
Here comes a fix for the problem discussed in https://github.com/mozart/mozart2/issues/204.
With this modification, cmake does not rely on sbt for install.
It only require the file 'bootcompiler.jar' to be recent enough.

I am not sure this is correct, so reviews are welcome.
