### PR TITLE
Implement addChildProcess() to kill child processes on termination

### DIFF
--- a/vm/boostenv/main/boostvm-decl.hh
+++ b/vm/boostenv/main/boostvm-decl.hh
@@ -94,7 +94,11 @@ public:
 
   void addMonitor(VMIdentifier monitor);
 
+  void addChildProcess(nativeint pid);
+
 private:
+  void killChildProcesses();
+
   void notifyMonitors();
 
   void terminate();
@@ -179,6 +183,10 @@ private:
   bool _terminationRequested;
   nativeint _terminationStatus;
   std::string _terminationReason;
+
+// Spawned child processes to kill when terminating
+private:
+  std::vector<nativeint> _childProcesses;
 
 // Running thread management
 private:

--- a/vm/boostenv/main/modos.hh
+++ b/vm/boostenv/main/modos.hh
@@ -890,8 +890,7 @@ public:
       vm->deleteStaticArray(argv, argc);
 
       if (doKill) {
-        // TODO
-        // addChildProc(pid);
+        BoostVM::forVM(vm).addChildProcess(pid);
       }
 
       outPid = build(vm, pid);
@@ -1004,8 +1003,7 @@ public:
 
       vm->deleteStaticArray(argv, argc);
 
-      // TODO
-      // addChildProc(pid);
+      BoostVM::forVM(vm).addChildProcess(pid);
 
       outPid = build(vm, pid);
       outStatus = buildSharp(vm, rsock, wsock);
@@ -1092,8 +1090,7 @@ public:
 
           vm->deleteStaticArray(argv, argc);
 
-          // TODO
-          // addChildProc(pid);
+          BoostVM::forVM(vm).addChildProcess(pid);
 
           outPid = build(vm, pid);
           outStatus = std::move(ozPipe);


### PR DESCRIPTION
- Implements the kill argument of OS.exec.
- Implements the automatic termination of processes spawned by OS.pipe.
- It notably kills the corresponding Tk instance when a VM terminates.

This still needs `{Application.exit 0}` or `{VM.kill {VM.current}}` to terminate of course as the Browser adds an IO node.
