### PR TITLE
Fix bug with PackWithReplacements when replacing top-level object with complex values.

### DIFF
--- a/platform-test/base/pickle.oz
+++ b/platform-test/base/pickle.oz
@@ -26,7 +26,6 @@ import
    %BootPickle(pack:Pack unpack:Unpack) at 'x-oz://boot/Pickle'
    Pickle(pack:Pack unpack:Unpack packWithReplacements:PackWithReplacements)
    BootName(newUnique:NewUniqueName newNamed:NewNamedName) at 'x-oz://boot/Name'
-   System
 export
    Return
 define
@@ -138,6 +137,17 @@ define
                    true = {IsCell A}
                    true = {IsCell B}
                    true = (A \= B)
+               end
+           )
+
+           packWithReplacementsTopLevel(
+               proc {$}
+                   A = {NewCell 1}
+                   VBS = {PackWithReplacements A [A#(a(b))]}
+                   U = {Unpack VBS}
+               in
+                   true = {IsCell A}
+                   U = a(b)
                end
            )
           ])

--- a/vm/vm/main/pickler.cc
+++ b/vm/vm/main/pickler.cc
@@ -75,10 +75,6 @@ void Pickler::pickle(RichNode value, RichNode temporaryReplacement) {
   auto typesRecord = RichNode(*vm->getPickleTypesRecord()).as<Record>();
   auto statelessTypes = RichNode(*typesRecord.getArity()).as<Arity>();
 
-  SerializationCallback cb(vm);
-  UnstableNode topLevelIndex = OptVar::build(vm);
-  cb.copy(topLevelIndex, value);
-
   bool futures = false;
   nativeint count = 0;
   VMAllocatedList<NodeBackup> nodeBackups;
@@ -104,9 +100,14 @@ void Pickler::pickle(RichNode value, RichNode temporaryReplacement) {
       nodeReplacementBackups.push_front(vm, replacement.first.makeBackup());
       replacement.first.reinit(vm, replacement.second);
     }
+    value.update();
 
     replacements.clear(vm);
   }
+
+  SerializationCallback cb(vm);
+  UnstableNode topLevelIndex = OptVar::build(vm);
+  cb.copy(topLevelIndex, value);
 
   // Replace serialized nodes by Serialized(index)
   // and add them to the nodes list


### PR DESCRIPTION
Basically, make this work:

```
A = {NewCell 1}
_ = {PackWithReplacments A [A#(a(b))]}
```

Current it fails with "Resources found during pickling", because a Reference is generated during replacement, and pickle.cc was not handling this.
