### PR TITLE
Implement OS.chDir

### DIFF
--- a/vm/boostenv/lib/OS.oz
+++ b/vm/boostenv/lib/OS.oz
@@ -46,11 +46,13 @@ export
    GetEnv
    PutEnv
 
-   % File I/0
+   % Directories
    GetDir
    GetCWD
+   ChDir
    Tmpnam
 
+   % File I/0
    Fopen
    Fread
    Fwrite
@@ -136,6 +138,7 @@ define
    end
 
    GetCWD = Boot_OS.getCWD
+   ChDir = Boot_OS.chDir
    Tmpnam = Boot_OS.tmpnam
 
    fun {Fopen FileName Mode}

--- a/vm/boostenv/main/modos.hh
+++ b/vm/boostenv/main/modos.hh
@@ -280,6 +280,24 @@ public:
     }
   };
 
+  class ChDir: public Builtin<ChDir> {
+  public:
+    ChDir(): Builtin("chDir") {}
+
+    static void call(VM vm, In dir) {
+      size_t dirBufSize = ozVSLengthForBuffer(vm, dir);
+      std::string dirStr;
+
+      ozVSGet(vm, dir, dirBufSize, dirStr);
+
+      boost::system::error_code ec;
+      boost::filesystem::current_path(dirStr, ec);
+      if (ec) {
+        raiseOSError(vm, "chdir", ec);
+      }
+    }
+  };
+
   class Tmpnam: public Builtin<Tmpnam> {
   public:
     Tmpnam(): Builtin("tmpnam") {}


### PR DESCRIPTION
* Disallowed when multiple VMs are running concurrently as
  it would make many filesystem operations nondeterministic.
* Fixes #248.