### PR TITLE
Upgrade to llvm/clang 3.7

### DIFF
--- a/vm/generator/main/builtins.cc
+++ b/vm/generator/main/builtins.cc
@@ -223,9 +223,10 @@ void handleBuiltinModule(const std::string& outputDir, const ClassDecl* CD,
   }
 
   {
-    std::string err;
-    llvm::raw_fd_ostream to((outputDir+name+"-builtin.json").c_str(), err);
-    assert(err == "");
+    std::error_code err;
+    llvm::raw_fd_ostream to((outputDir+name+"-builtin.json").c_str(), err,
+                            llvm::sys::fs::F_None);
+    assert(!err);
     definition.makeOutput(to);
   }
 

--- a/vm/generator/main/generator.cc
+++ b/vm/generator/main/generator.cc
@@ -77,8 +77,7 @@ void processDeclContext(const std::string outputDir, const DeclContext* ds,
 }
 
 int main(int argc, char* argv[]) {
-  llvm::IntrusiveRefCntPtr<DiagnosticsEngine> Diags;
-  FileSystemOptions FileSystemOpts;
+  CompilerInstance CI;
 
   std::string modeStr = argv[1];
   std::string astFile = argv[2];
@@ -105,9 +104,13 @@ int main(int argc, char* argv[]) {
   }
 
   // Parse source file
-  ASTUnit *unit = ASTUnit::LoadFromASTFile(astFile,
-                                           Diags, FileSystemOpts,
-                                           false, 0, 0, true);
+  CI.createDiagnostics();
+  IntrusiveRefCntPtr<DiagnosticsEngine> Diags(&CI.getDiagnostics());
+  std::unique_ptr<ASTUnit> unit =
+      ASTUnit::LoadFromASTFile(astFile,
+                               CI.getPCHContainerReader(),
+                               Diags,
+                               CI.getFileSystemOpts());
 
   // Setup printing policy
   // We want the bool type to be printed as "bool"

--- a/vm/generator/main/generator.hh
+++ b/vm/generator/main/generator.hh
@@ -29,6 +29,7 @@
 
 #include <clang/Frontend/ASTUnit.h>
 #include <clang/AST/DeclTemplate.h>
+#include <clang/Frontend/CompilerInstance.h>
 
 typedef clang::ClassTemplateSpecializationDecl SpecDecl;
 typedef clang::CXXRecordDecl ClassDecl;
@@ -36,17 +37,18 @@ typedef clang::CXXRecordDecl ClassDecl;
 typedef llvm::raw_fd_ostream ostream;
 
 inline
-void checkErrString(const std::string& err) {
-  if (!err.empty()) {
-    llvm::errs() << err << "\n";
+void checkErrString(const std::error_code& err) {
+  if (err) {
+    llvm::errs() << err.message() << "\n";
     exit(1);
   }
 }
 
 inline
 std::unique_ptr<ostream> openFileOutputStream(const std::string& fileName) {
-  std::string err;
-  auto result = std::unique_ptr<ostream>(new ostream(fileName.c_str(), err));
+  std::error_code err;
+  auto result = std::unique_ptr<ostream>(new ostream(fileName.c_str(), err,
+                                                     llvm::sys::fs::F_None));
   checkErrString(err);
 
   return result;
@@ -55,8 +57,8 @@ std::unique_ptr<ostream> openFileOutputStream(const std::string& fileName) {
 inline
 void withFileOutputStream(const std::string& fileName,
                           std::function<void (ostream&)> body) {
-  std::string err;
-  ostream stream(fileName.c_str(), err);
+  std::error_code err;
+  ostream stream(fileName.c_str(), err, llvm::sys::fs::F_None);
   checkErrString(err);
 
   body(stream);

--- a/vm/generator/main/implementations.cc
+++ b/vm/generator/main/implementations.cc
@@ -520,7 +520,7 @@ void ImplementationDef::makeOutput(llvm::raw_fd_ostream& to) {
        << method->formals << ") {\n";
 
     to << "  ";
-    if (!method->function->getResultType().getTypePtr()->isVoidType())
+    if (!method->function->getReturnType().getTypePtr()->isVoidType())
       to << "return ";
 
     to << access << method->name;

--- a/vm/generator/main/utils.cc
+++ b/vm/generator/main/utils.cc
@@ -213,7 +213,7 @@ void parseFunction(const clang::FunctionDecl* function,
                    bool hasSelfParam) {
 
   name = function->getNameAsString();
-  resultType = typeToString(function->getResultType());
+  resultType = typeToString(function->getReturnType());
 
   auto param_begin = function->param_begin() + (hasSelfParam ? 1 : 0);
   auto param_end = function->param_end();


### PR DESCRIPTION
With this set of fixes, I am able to build mozart2 against llvm/clang 3.7.
This in turns allows to make builds for the new tcl/tk around.

Of course the documentation needs to be updated, but the previous pull request is still pending...