### PR TITLE
Question: Ambiguity in resolving BoostBigInt Constructor

### DIFF
--- a/vm/boostenv/main/boostenvbigint-decl.hh
+++ b/vm/boostenv/main/boostenvbigint-decl.hh
@@ -92,8 +92,15 @@ public:
   void printReprToStream(VM vm, std::ostream& out, int depth, int width);
 
 public:
-  template <class T>
-  static std::shared_ptr<BigIntImplem> make_shared_ptr(const T& value) {
+  static std::shared_ptr<BigIntImplem> make_shared_ptr(const mp_int& value) {
+    return std::static_pointer_cast<BigIntImplem>(std::make_shared<BoostBigInt>(value));
+  }
+
+  static std::shared_ptr<BigIntImplem> make_shared_ptr(const std::string& value) {
+    return std::static_pointer_cast<BigIntImplem>(std::make_shared<BoostBigInt>(value));
+  }
+
+  static std::shared_ptr<BigIntImplem> make_shared_ptr(const nativeint& value) {
     return std::static_pointer_cast<BigIntImplem>(std::make_shared<BoostBigInt>(value));
   }
 


### PR DESCRIPTION
Can someone explain me the bug ?

Apparently gcc has trouble finding if it should use `BoostBigInt(const BoostBigInt& src) = delete;` or `BoostBigInt(const mp_int& value) : _value(value) {};` when calling `BoostBigInt::make_shared_ptr()`.

See https://github.com/mozart/mozart2/compare/master...layus:ambiguity#diff-d538b165a32a379c453ff0e77568ab38 for a fix that works for me.

PS : /usr/include/c++/5.3.0/ext/new_allocator.h:120:4: erreur: call of overloaded ‘BoostBigInt(const boost::multiprecision::detail::expression<boost::multiprecision::detail::subtract_immediates, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<> >, boost::multiprecision::number<boost::multiprecision::backends::cpp_int_backend<> >, void, void>&)’ is ambiguous
  { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }

