### PR TITLE
Ensure field unicity for records

### DIFF
--- a/vm/vm/main/dynbuilders-decl.hh
+++ b/vm/vm/main/dynbuilders-decl.hh
@@ -83,10 +83,6 @@ struct UnstableField {
 
 template <class T>
 inline
-void sortFeatures(VM vm, size_t width, T features[]);
-
-template <class T>
-inline
 UnstableNode buildArityDynamic(VM vm, RichNode label, size_t width,
                                T elements[]);
 


### PR DESCRIPTION
This patch checks that all the features of a record are distinct.

For the following example

``` oz
declare A = a
{Browse abc(a:1 b:1 a:2 c:1 a:3)}             %1
thread {Browse abc(A:1 b:1 a:2 c:1 a:3)} end  %2
{Browse {Record.make abc [a b a c a]}}        %3
```

we get (separately)

```
### 1 ###
%********************** static analysis error *******************
%**
%** duplicate feature in record construction
%**
%** Features found: {a, b, a, c, a}
%** in file "Oz", line 3, column 16
%** ------------------ rejected (1 error)

### 2 ###
%********************* Error: duplicate fields ******************
%**
%** Duplicate fields in record construction
%**
%** Label:               abc
%** Feature-field Pairs: a#1 a#2 a#3 b#1 c#1
%**
%** Call Stack:
%** procedure 'Record.makeDynamic' in PC = 139701193282288
%** procedure in file "Oz", line 3, column 1, PC = 139701173938231
%**--------------------------------------------------------------

### 3 ###
%********************* Error: duplicate fields ******************
%**
%** Duplicate fields in record construction
%**
%** Label:               abc
%** Feature-field Pairs: a#_<optimized> a#_<optimized> a#_<optimized> b#_<optimized> c#_<optimized>
%**
%** Call Stack:
%** procedure 'Record.makeDynamic' in PC = 139701193282288
%** toplevel abstraction in line 1, column 0, PC = 139701294106019
%**--------------------------------------------------------------
```

I am still unhappy with the reordering that occurs in the error messages. I think th "Feature-field Pairs" should be printed in the order they were passed to Boot_record.makeDynamic, not the order resulting from the unstable std::sort.

With the first error, the static analyser catches the kernel error and prints the list of features in the correct order. Mozart1 used to return the unsorted features in all the cases.

That being said, I think this error code could be redesigned from scratch, and that the order of the features in the specific case of duplicate features is not really relevant. This is why I suggest to merge this patch.

@sjrd As usual, comments on C++ style are more than welcome.

Fixes #285 
