### PR TITLE
Update Emacs lisp library headers to follow the conventions

### DIFF
--- a/opi/emacs/mozart.el
+++ b/opi/emacs/mozart.el
@@ -1,33 +1,27 @@
-;;;
-;;; Authors:
-;;;   Leif Kornstaedt <kornstae@ps.uni-sb.de>
-;;;   Michael Mehl <mehl@ps.uni-sb.de>
-;;;   Ralf Scheidhauer <scheihr@ps.uni-sb.de>
-;;;
-;;; Contributor:
-;;;   Benjamin Lorenz <lorenz@ps.uni-sb.de>
-;;;   Denys Duchier <duchier@ps.uni-sb.de>
-;;;
-;;; Copyright:
-;;;   Leif Kornstaedt, Michael Mehl, and Ralf Scheidhauer, 1993-1998
-;;;   Denys Duchier, 1998
-;;;
-;;; Last change:
-;;;   $Date$ by $Author$
-;;;   $Revision$
-;;;
-;;; This file is part of Mozart, an implementation of Oz 3:
-;;;   http://www.mozart-oz.org
-;;;
-;;; See the file "LICENSE" or
-;;;   http://www.mozart-oz.org/LICENSE.html
-;;; for information on usage and redistribution
-;;; of this file, and for a DISCLAIMER OF ALL
-;;; WARRANTIES.
-;;;
+;;; mozart.el --- Functions for running a Mozart sub-process.
 
-;; Functions for running a Mozart sub-process
+;; Copyright (c) 1993-1998  Leif Kornstaedt
+;; Copyright (c) 1993-1998  Michael Mehl
+;; Copyright (c) 1993-1998  Ralf Scheidhauer
+;; Copyright (c) 1998  Denys Duchier
+
+;; This file is part of Mozart, an implementation of Oz 3:
+;;   http://www.mozart-oz.org
+
+;; Authors:
+;;   Leif Kornstaedt <kornstae@ps.uni-sb.de>
+;;   Michael Mehl <mehl@ps.uni-sb.de>
+;;   Ralf Scheidhauer <scheihr@ps.uni-sb.de>
+;; Contributors:
+;;   Benjamin Lorenz <lorenz@ps.uni-sb.de>
+;;   Denys Duchier <duchier@ps.uni-sb.de>
+;; License: BSD-2-clause
+
+;;; Commentary:
 ;;
+;; Functions for running a Mozart sub-process.
+
+;;; Code:
 
 (require 'oz)
 (require 'comint)
@@ -1931,3 +1925,4 @@ Commands:
 ;;; byte-compile-dynamic-docstrings: nil ***
 ;;; byte-compile-compatibility: t ***
 ;;; End: ***
+;;; mozart.el ends here

--- a/opi/emacs/oz-extra.el
+++ b/opi/emacs/oz-extra.el
@@ -1,3 +1,16 @@
+;;; oz-extra.el --- Outline mode support
+
+;; This file is part of Mozart, an implementation of Oz 3:
+;;   http://www.mozart-oz.org
+
+;; License: BSD-2-clause
+
+;;; Commentary:
+;;
+;; Outline mode support.
+
+;;; Code:
+
 (require 'outline)
 
 (defvar oz-outline-mode nil)
@@ -44,3 +57,4 @@
 ;;; byte-compile-dynamic-docstrings: nil ***
 ;;; byte-compile-compatibility: t ***
 ;;; End: ***
+;;; oz-extra.el ends here

--- a/opi/emacs/oz-server.el
+++ b/opi/emacs/oz-server.el
@@ -1,35 +1,28 @@
-;;;
-;;; Authors:
-;;;   Denys Duchier <duchier@ps.uni-sb.de>
-;;;
-;;; Contributors:
-;;;
-;;; Copyright:
-;;;   Denys Duchier, 2000
-;;;
-;;; Last change:
-;;;   $Date$ by $Author$
-;;;   $Revision$
-;;;
-;;; This file is part of Mozart, an implementation of Oz 3:
-;;;   http://www.mozart-oz.org
-;;;
-;;; See the file "LICENSE" or
-;;;   http://www.mozart-oz.org/LICENSE.html
-;;; for information on usage and redistribution
-;;; of this file, and for a DISCLAIMER OF ALL
-;;; WARRANTIES.
-;;;
+;;; oz-server.el --- Uniform framework to allow interacting with Oz process.
 
-;;; ==================================================================
-;;; This file implements a more principled and uniform framework to
-;;; allow emacs and the Oz process to interact.  The idea is to create
-;;; a socket connection on which the two processes can exchange
-;;; messages.  By design, the set of message types which can be
-;;; exchanged is indefinitely extensible.
-;;; ==================================================================
+;; Copyright (c) 2000  Denys Duchier
 
-(provide 'oz-server)
+;; This file is part of Mozart, an implementation of Oz 3:
+;;   http://www.mozart-oz.org
+
+;; Authors:
+;;   Leif Kornstaedt <kornstae@ps.uni-sb.de>
+;;   Michael Mehl <mehl@ps.uni-sb.de>
+;;   Ralf Scheidhauer <scheihr@ps.uni-sb.de>
+;; Contributors:
+;;   Benjamin Lorenz <lorenz@ps.uni-sb.de>
+;;   Denys Duchier <duchier@ps.uni-sb.de>
+;; License: BSD-2-clause
+
+;;; Commentary:
+;;
+;; This file implements a more principled and uniform framework to
+;; allow emacs and the Oz process to interact.  The idea is to create
+;; a socket connection on which the two processes can exchange
+;; messages.  By design, the set of message types which can be
+;; exchanged is indefinitely extensible.
+
+;;; Code:
 
 (defconst oz-server-name "*Oz Server*"
   "name of the server process")
@@ -375,3 +368,6 @@ back a replyError."
             vals)))
     (setq oz-server-synchronous-polling nil
           oz-server-synchronous-reply   nil)))
+
+(provide 'oz-server)
+;;; oz-server.el ends here

--- a/opi/emacs/oz.el
+++ b/opi/emacs/oz.el
@@ -1,33 +1,27 @@
-;;;
-;;; Authors:
-;;;   Leif Kornstaedt <kornstae@ps.uni-sb.de>
-;;;   Michael Mehl <mehl@ps.uni-sb.de>
-;;;   Ralf Scheidhauer <scheihr@ps.uni-sb.de>
-;;;
-;;; Contributor:
-;;;   Benjamin Lorenz <lorenz@ps.uni-sb.de>
-;;;   Denys Duchier <duchier@ps.uni-sb.de>
-;;;
-;;; Copyright:
-;;;   Leif Kornstaedt, Michael Mehl, and Ralf Scheidhauer, 1993-1998
-;;;   Denys Duchier, 1998
-;;;
-;;; Last change:
-;;;   $Date$ by $Author$
-;;;   $Revision$
-;;;
-;;; This file is part of Mozart, an implementation of Oz 3:
-;;;   http://www.mozart-oz.org
-;;;
-;;; See the file "LICENSE" or
-;;;   http://www.mozart-oz.org/LICENSE.html
-;;; for information on usage and redistribution
-;;; of this file, and for a DISCLAIMER OF ALL
-;;; WARRANTIES.
-;;;
+;;; oz.el --- Major mode for editing Oz programs.
 
-;; Major mode for editing Oz programs
+;; Copyright (c) 1993-1998  Leif Kornstaedt
+;; Copyright (c) 1993-1998  Michael Mehl
+;; Copyright (c) 1993-1998  Ralf Scheidhauer
+;; Copyright (c) 1998  Denys Duchier
+
+;; This file is part of Mozart, an implementation of Oz 3:
+;;   http://www.mozart-oz.org
+
+;; Authors:
+;;   Leif Kornstaedt <kornstae@ps.uni-sb.de>
+;;   Michael Mehl <mehl@ps.uni-sb.de>
+;;   Ralf Scheidhauer <scheihr@ps.uni-sb.de>
+;; Contributors:
+;;   Benjamin Lorenz <lorenz@ps.uni-sb.de>
+;;   Denys Duchier <duchier@ps.uni-sb.de>
+;; License: BSD-2-clause
+
+;;; Commentary:
 ;;
+;; Major mode for editing Oz programs.
+
+;;; Code:
 
 ;;{{{ Global Effects
 
@@ -1693,3 +1687,4 @@ prefix ARG is negated."
 ;;; byte-compile-dynamic-docstrings: nil ***
 ;;; byte-compile-compatibility: t ***
 ;;; End: ***
+;;; oz.el ends here


### PR DESCRIPTION
* Explicitly specify the license in each library instead of revering
  to a LICENSE file which is not available when the user installs an
  Emacs package using `package.el' or from the Emacsmirror.

  This change allows me to keep distributing this on the Emacsmirror.

* Update the header and footer to follow the conventions.

  This should allow distributing the package on Melpa.  But you will
  have to submit a recipe yourself and be ready to go through the
  review process.