### PR TITLE
Hide cell content when displaying values.

### DIFF
--- a/vm/vm/main/cell-decl.hh
+++ b/vm/vm/main/cell-decl.hh
@@ -70,7 +70,7 @@ public:
   // Miscellaneous
 
   void printReprToStream(VM vm, std::ostream& out, int depth, int width) {
-    out << "<Cell: " << repr(vm, _value, depth, width) << ">";
+    out << "<Cell>";
   }
 
 private:


### PR DESCRIPTION
Displaying cell content breaks the Browser on recursive cells.
This is the laziest fix, another option would be to add support for
celle expansion in the browser, but this would require updating the
browser when the content of the cell changes.

Closes #167