### PR TITLE
Change call to ozemulator with exec in ozengine

### DIFF
--- a/boosthost/emulator/ozengine
+++ b/boosthost/emulator/ozengine
@@ -12,4 +12,4 @@ then
 fi
 export OZHOME
 
-"$OZHOME/bin/ozemulator" "$@"
+exec "$OZHOME/bin/ozemulator" "$@"


### PR DESCRIPTION
I noticed that killing ozengine in Linux does not kill the process ozemulator.