### PR TITLE
Update Mac OS's installation guide's section about brew cask

### DIFF
--- a/README.MacOS.md
+++ b/README.MacOS.md
@@ -14,14 +14,12 @@ Download and install the following tools:
 
 In case you don't have plans to work on Mozart 2
 and you have Homebrew already installed,
-you can simply install it as a compiled binary via [Homebrew cask]:
+you can simply install it as a compiled binary via Homebrew's cask option:
 
 ```shell
 brew tap dskecse/tap
 brew install --cask mozart2
 ```
-
-[Homebrew cask]: https://caskroom.github.io/
 
 ### Homebrew formula
 

--- a/README.MacOS.md
+++ b/README.MacOS.md
@@ -7,7 +7,7 @@ In order to build the system on MacOS you need at least the 10.8 version of the 
 Download and install the following tools:
 
 *  [Mac OS development tools](http://developer.apple.com)
-*  [Homebrew](http://mxcl.github.com/homebrew/).
+*  [Homebrew](https://brew.sh/).
 *   Any emacs distribution, for instance [Aquamacs](http://aquamacs.org/).
 
 ### Homebrew cask

--- a/README.MacOS.md
+++ b/README.MacOS.md
@@ -18,7 +18,7 @@ you can simply install it as a compiled binary via [Homebrew cask]:
 
 ```shell
 brew tap dskecse/tap
-brew cask install mozart2
+brew install --cask mozart2
 ```
 
 [Homebrew cask]: https://caskroom.github.io/


### PR DESCRIPTION
### Problems
1. The old brew cask command is not working anymore.
2. Brew cask has been merged with brew so a link to brew cask's repository is not relevant anymore.
3. The link to brew's repository is redirecting to the official website so why not replace it with the official website's one ?

### Fixes
All the previously mentioned elements have been fixed. All the fixes are explained in their respective commits.