### PR TITLE
update pointers for modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "stdlib"]
 	path = stdlib
-	url = git://github.com/mozart/mozart2-stdlib.git
+	url = https://github.com/mozart/mozart2-stdlib.git
 [submodule "gtest"]
 	path = vm/vm/test/gtest
-	url = http://github.com/google/googletest
+	url = https://github.com/google/googletest


### PR DESCRIPTION
The `git submodule update --init` complains with "The unauthenticated git protocol on port 9418 is no longer supported". Updating the `.gitmodules` allowed me to run the command successfully.