### PR TITLE
Make project build with latest dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.o
 *.a
 
+# For ease of use as cmake build directory
+/build

--- a/bootcompiler/CMakeLists.txt
+++ b/bootcompiler/CMakeLists.txt
@@ -4,7 +4,7 @@ project(MOZARTBOOTCOMPILER NONE)
 find_package(Java COMPONENTS Runtime REQUIRED)
 
 set(SBT_JAVA_OPTS
-    -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M
+    -Xms512M -Xmx1024M -Xss1M
     CACHE STRING "Options passed to the Java executable when running sbt")
 
 set(SBT "${Java_JAVA_EXECUTABLE}" ${SBT_JAVA_OPTS} -Dfile.encoding=UTF-8
@@ -12,9 +12,9 @@ set(SBT "${Java_JAVA_EXECUTABLE}" ${SBT_JAVA_OPTS} -Dfile.encoding=UTF-8
 
 file(GLOB_RECURSE bootcompiler_sources src/*)
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/bootcompiler.jar"
-  COMMAND ${SBT} oneJar
+  COMMAND ${SBT} assembly
   COMMAND ${CMAKE_COMMAND} -E copy
-    "${CMAKE_CURRENT_SOURCE_DIR}/target/scala-2.11/bootcompiler_2.11-2.0-SNAPSHOT-one-jar.jar"
+    "${CMAKE_CURRENT_SOURCE_DIR}/target/scala-2.13/bootcompiler-assembly-2.0-SNAPSHOT.jar"
     "${CMAKE_CURRENT_BINARY_DIR}/bootcompiler.jar"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS "sbt-launch.jar" "build.sbt" "project/plugins.sbt" ${bootcompiler_sources}

--- a/bootcompiler/build.sbt
+++ b/bootcompiler/build.sbt
@@ -2,16 +2,18 @@ name := "bootcompiler"
 
 version := "2.0-SNAPSHOT"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.13.8"
 
-scalacOptions ++= Seq("-deprecation", "-optimize")
+scalacOptions ++= Seq("-language:postfixOps", "-deprecation", "-optimize")
 
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"
-
-libraryDependencies += "com.github.scopt" %% "scopt" % "3.2.0"
-
-seq(com.github.retronym.SbtOneJar.oneJarSettings: _*)
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "2.1.1"
+libraryDependencies += "com.github.scopt" %% "scopt" % "4.1.0"
+libraryDependencies += "io.spray" %% "spray-json" % "1.3.6"
 
 // Work around a bug that prevents generating documentation
 unmanagedClasspath in Compile +=
     Attributed.blank(new java.io.File("doesnotexist"))
+
+// Added during migration to the java 9 module system
+Compile / packageBin / packageOptions +=
+  Package.ManifestAttributes("Add-Exports" -> "java.base/jdk.internal.math")

--- a/bootcompiler/project/build.properties
+++ b/bootcompiler/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=1.6.2

--- a/bootcompiler/project/plugins.sbt
+++ b/bootcompiler/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.github.retronym" % "sbt-onejar" % "0.8")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/bootcompiler/sbt
+++ b/bootcompiler/sbt
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
-java ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled \
-  -XX:MaxPermSize=384M ${JAVA_OPTS} -Dfile.encoding=UTF-8 \
+java ${DEBUG_PARAM} -Xms512M -Xmx1536M -Xss1M \
+  ${JAVA_OPTS} -Dfile.encoding=UTF-8 \
   -jar `dirname $0`/sbt-launch.jar "$@"

--- a/bootcompiler/sbt.bat
+++ b/bootcompiler/sbt.bat
@@ -1,4 +1,4 @@
 @echo off
 
 set SCRIPT_DIR=%~dp0
-java -Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M %JAVA_OPTS% -Dfile.encoding=UTF-8 -jar "%SCRIPT_DIR%sbt-launch.jar" %*
+java -Xms512M -Xmx1024M -Xss1M %JAVA_OPTS% -Dfile.encoding=UTF-8 -jar "%SCRIPT_DIR%sbt-launch.jar" %*

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/Main.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/Main.scala
@@ -71,10 +71,8 @@ object Main {
         .text("input file")
     }
 
-
     // Parse the options
-    optParser.parse(args, Config()) map { config =>
-      // OK, we're good to go
+    optParser.parse(args, Config()).foreach({ config =>
       try {
         config.mode match {
           case Config.Mode.Module =>
@@ -89,7 +87,7 @@ object Main {
           th.printStackTrace()
           sys.exit(2)
       }
-    }
+    })
   }
 
   /** Performs the Module mode */
@@ -220,8 +218,6 @@ object Main {
    *  @param moduleDefs list of files that define builtin modules
    */
   private def loadModuleDefs(prog: Program, moduleDefs: List[String]) = {
-    // JSON.globalNumberParser = (_.toInt)
-
     val result = new scala.collection.mutable.HashMap[String, Expression]
 
     for (moduleDef <- moduleDefs) {
@@ -260,9 +256,9 @@ object Main {
     )
 
     object ModuleJsonProtocol extends DefaultJsonProtocol {
-      implicit val parameterJsonFormat = jsonFormat1(JsParameter)
-      implicit val builtinJsonFormat = jsonFormat4(JsBuiltin)
-      implicit val moduleJsonFormat = jsonFormat2(JsModule)
+      implicit val parameterJsonFormat: RootJsonFormat[JsParameter] = jsonFormat1(JsParameter)
+      implicit val builtinJsonFormat: RootJsonFormat[JsBuiltin] = jsonFormat4(JsBuiltin)
+      implicit val moduleJsonFormat: RootJsonFormat[JsModule] = jsonFormat2(JsModule)
     }
 
     import ModuleJsonProtocol._
@@ -280,8 +276,6 @@ object Main {
       val inlineAs: Option[Int] =
         if (jsBuiltin.inlineable) jsBuiltin.inlineOpCode
         else None
-        // if (inlineable) Some(bi("inlineOpCode").asInstanceOf[Int])
-        // else None
 
       val paramKinds = for {
         jsParam <- jsBuiltin.params

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ProgramBuilder.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ProgramBuilder.scala
@@ -19,7 +19,7 @@ object ProgramBuilder extends TreeDSL with TransformUtils {
    *  end
    *  }}}
    */
-  def buildModuleProgram(prog: Program, functor: Expression) {
+  def buildModuleProgram(prog: Program, functor: Expression): Unit = {
     prog.rawCode = {
       prog.topLevelResultSymbol === functor
     }
@@ -65,7 +65,7 @@ object ProgramBuilder extends TreeDSL with TransformUtils {
    */
   def buildBaseEnvProgram(prog: Program,
       bootModulesMap: Map[String, Expression],
-      baseFunctor0: Expression) {
+      baseFunctor0: Expression): Unit = {
 
     val baseFunctor = baseFunctor0.asInstanceOf[FunctorExpression]
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/Serializer.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/Serializer.scala
@@ -12,7 +12,7 @@ class Serializer(program: Program, output: BufferedOutputStream) {
 
   // Top-level
 
-  def serialize() {
+  def serialize(): Unit = {
     val topLevelCodeArea = OzCodeArea(program.topLevelAbstraction.codeArea)
     val topLevelValue = OzAbstraction(topLevelCodeArea, Nil)
     giveIndex(topLevelValue)
@@ -28,14 +28,14 @@ class Serializer(program: Program, output: BufferedOutputStream) {
 
   // Give indices to nodes
 
-  private def giveIndex(value: OzValue) {
+  private def giveIndex(value: OzValue): Unit = {
     nodeToIndex.getOrElseUpdate(value, {
       giveIndicesInside(value)
       indexCounter.next()
     })
   }
 
-  private def giveIndicesInside(value: OzValue) {
+  private def giveIndicesInside(value: OzValue): Unit = {
     value match {
       case OzCons(head, tail) =>
         giveIndex(head)
@@ -74,7 +74,7 @@ class Serializer(program: Program, output: BufferedOutputStream) {
 
   // Writing of nodes
 
-  private def writeValue(index: Int, value: OzValue) {
+  private def writeValue(index: Int, value: OzValue): Unit = {
     writeSize(index)
 
     value match {
@@ -153,7 +153,7 @@ class Serializer(program: Program, output: BufferedOutputStream) {
     }
   }
 
-  private def writeCodeArea(codeArea: CodeArea) {
+  private def writeCodeArea(codeArea: CodeArea): Unit = {
     val codeBlock = for {
       opCode <- codeArea.opCodes.toList
       byteCodeElem <- opCode.encoding
@@ -178,38 +178,38 @@ class Serializer(program: Program, output: BufferedOutputStream) {
 
   // Low-level write procs
 
-  private def writeSize(size: Int) {
+  private def writeSize(size: Int): Unit = {
     output.write(size >> 24 & 0xff)
     output.write(size >> 16 & 0xff)
     output.write(size >> 8 & 0xff)
     output.write(size & 0xff)
   }
 
-  private def writeByte(b: Int) {
+  private def writeByte(b: Int): Unit = {
     output.write(b)
   }
 
-  private def writeString(str: String) {
+  private def writeString(str: String): Unit = {
     val bytes = str.getBytes(Serializer.charset)
     writeSize(bytes.length)
     output.write(bytes)
   }
 
-  private def writeAtom(atom: String) {
+  private def writeAtom(atom: String): Unit = {
     writeString(atom)
   }
 
-  private def writeRef(value: OzValue) {
+  private def writeRef(value: OzValue): Unit = {
     writeSize(nodeToIndex(value))
   }
 
-  private def writeRefs(values: Seq[OzValue]) {
+  private def writeRefs(values: Seq[OzValue]): Unit = {
     writeSize(values.size)
     values foreach writeRef
   }
 
-  private def writeRandomUUID() {
-    def writeLong(value: Long) {
+  private def writeRandomUUID(): Unit = {
+    def writeLong(value: Long): Unit = {
       for (i <- (0 until 64 by 8).reverse)
         output.write(((value >> i) & 0xff).asInstanceOf[Int])
     }
@@ -223,7 +223,7 @@ class Serializer(program: Program, output: BufferedOutputStream) {
 object Serializer {
   val charset = java.nio.charset.Charset.forName("UTF-8")
 
-  def serialize(program: Program, output: BufferedOutputStream) {
+  def serialize(program: Program, output: BufferedOutputStream): Unit = {
     new Serializer(program, output).serialize()
   }
 }

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Node.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/ast/Node.scala
@@ -32,9 +32,9 @@ abstract class Node extends Product with Positional {
    *
    *  @param handler handler callback
    */
-  def walkBreak(handler: Node => Boolean) {
+  def walkBreak(handler: Node => Boolean): Unit = {
     if (handler(this)) {
-      def inner(element: Any) {
+      def inner(element: Any): Unit = {
         element match {
           case node:Node => node.walk(handler)
           case seq:Seq[_] => seq foreach inner
@@ -52,7 +52,7 @@ abstract class Node extends Product with Positional {
    *
    *  @param handler handler callback
    */
-  def walk[U](handler: Node => U) {
+  def walk[U](handler: Node => U): Unit = {
     walkBreak { node =>
       handler(node)
       true

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/bytecode/CodeArea.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/bytecode/CodeArea.scala
@@ -24,7 +24,7 @@ class CodeArea(val abstraction: Abstraction) {
 
   override def toString() = "<CodeArea %s>" format (abstraction.fullName)
 
-  def dump(includeByteCode: Boolean = true) {
+  def dump(includeByteCode: Boolean = true): Unit = {
     println("constants:")
     for ((constant, index) <- constants.zipWithIndex)
       println("  K(%d) = %s" format (index, constant))
@@ -62,7 +62,7 @@ class CodeArea(val abstraction: Abstraction) {
     opCodes += opCode
 
   class Hole(index: Int) {
-    def fillWith(opCode: OpCode) {
+    def fillWith(opCode: OpCode): Unit = {
       opCodes(index) = opCode
     }
   }

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/parser/OzPreprocessor.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/parser/OzPreprocessor.scala
@@ -3,8 +3,6 @@ package parser
 
 import java.io.{ File, FileReader, BufferedReader }
 
-import scala.collection.immutable.PagedSeq
-
 import scala.util.parsing.input._
 import scala.util.parsing.combinator.token._
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Abstraction.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Abstraction.scala
@@ -42,7 +42,7 @@ class Abstraction(val owner: Abstraction, val name: String, val pos: Position) {
   def arity = formals.size
 
   /** Acquires a symbol as being declared in this abstraction */
-  def acquire(symbol: Symbol) {
+  def acquire(symbol: Symbol): Unit = {
     symbol.setOwner(this)
     if (symbol.isFormal) formals += symbol
     else if (symbol.isGlobal) globals += symbol
@@ -75,7 +75,7 @@ class Abstraction(val owner: Abstraction, val name: String, val pos: Position) {
    *
    *  @param includeByteCode include the bytecode in the dump
    */
-  def dump(includeByteCode: Boolean = true) {
+  def dump(includeByteCode: Boolean = true): Unit = {
     println(fullName + ": P/" + arity.toString())
     println("  formals: " + (formals mkString " "))
     println("  locals: " + (locals mkString " "))

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Builtins.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Builtins.scala
@@ -15,7 +15,7 @@ class Builtins {
   private val builtins = new HashMap[(String, String), Builtin]
 
   /** Registers a builtin */
-  def register(builtin: Builtin) {
+  def register(builtin: Builtin): Unit = {
     builtins += (builtin.moduleName, builtin.name) -> builtin
   }
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Program.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Program.scala
@@ -56,7 +56,7 @@ class Program(val isBaseEnvironment: Boolean = false) {
    *  @param message error message
    *  @param pos position of the error
    */
-  def reportError(message: String, pos: Position = NoPosition) {
+  def reportError(message: String, pos: Position = NoPosition): Unit = {
     errors += ((message, pos))
   }
 
@@ -64,12 +64,12 @@ class Program(val isBaseEnvironment: Boolean = false) {
    *  @param message error message
    *  @param positional positional that holds the position of the error
    */
-  def reportError(message: String, positional: Positional) {
+  def reportError(message: String, positional: Positional): Unit = {
     reportError(message, positional.pos)
   }
 
   /** Dumps the program on standard error */
-  def dump() {
+  def dump(): Unit = {
     if (isRawCode)
       println(rawCode)
     else {

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Symbol.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/symtab/Symbol.scala
@@ -31,7 +31,7 @@ sealed class Symbol(_name: String, formal: Boolean = false,
   def owner = _owner
 
   /** Sets the owning abstraction */
-  def setOwner(owner: Abstraction) {
+  def setOwner(owner: Abstraction): Unit = {
     _owner = owner
   }
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/CodeGen.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/CodeGen.scala
@@ -16,11 +16,11 @@ object CodeGen extends Transformer with TreeDSL {
     code.registerFor(expr)
 
   private implicit def reg2ops[A <: Register](self: A) = new {
-    def := (source: Register)(implicit ev: A <:< XOrYReg) {
+    def := (source: Register)(implicit ev: A <:< XOrYReg): Unit = {
       code += OpMove(source, self)
     }
 
-    def === (rhs: Register) {
+    def === (rhs: Register): Unit = {
       code += OpUnify(self, rhs)
     }
   }
@@ -33,7 +33,7 @@ object CodeGen extends Transformer with TreeDSL {
     def toReg = code.registerFor(self)
   }
 
-  def initArrayWith(values: List[Expression]) {
+  def initArrayWith(values: List[Expression]): Unit = {
     for (value <- values) {
       varorconst2reg(value.asInstanceOf[VarOrConst]) match {
         case v:XReg => code += SubOpArrayFillX(v)
@@ -44,7 +44,7 @@ object CodeGen extends Transformer with TreeDSL {
     }
   }
 
-  override def applyToAbstraction() {
+  override def applyToAbstraction(): Unit = {
     // Allocate local variables
     val localCount = abstraction.formals.size + abstraction.locals.size
     if (localCount != 0)
@@ -65,7 +65,7 @@ object CodeGen extends Transformer with TreeDSL {
     code += OpReturn()
   }
 
-  def generate(statement: Statement) {
+  def generate(statement: Statement): Unit = {
     statement match {
       case SkipStatement() =>
         // skip

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/ConstantFolding.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/ConstantFolding.scala
@@ -8,7 +8,7 @@ import symtab._
 object ConstantFolding extends Transformer with TreeDSL {
   import Utils._
 
-  override protected def apply() {
+  override protected def apply(): Unit = {
     program.rawCode = transformRoot(program.rawCode)
   }
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/DesugarClass.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/DesugarClass.scala
@@ -300,7 +300,7 @@ object DesugarClass extends Transformer with TreeDSL {
 
     atPos(method) {
       PROC (name, List(selfParam, msgParam)) {
-        LOCAL (paramVars:_*) IN {
+        LOCAL (paramVars.toSeq:_*) IN {
           withSelf(selfParam) {
             transformStat {
               CompoundStatement(fetchParamStats.toList) ~ {

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Flattener.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Flattener.scala
@@ -10,7 +10,7 @@ import symtab._
 object Flattener extends Transformer with TreeDSL {
   private var globalToFreeVar: Map[Symbol, Symbol] = _
 
-  override def apply() {
+  override def apply(): Unit = {
     val rawCode = program.rawCode
     program.rawCode = null
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Namer.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Namer.scala
@@ -399,7 +399,7 @@ object Namer extends Transformer with TransformUtils with TreeDSL {
         val initNames = CompoundStatement(for {
           decl <- namedDecls
         } yield {
-          decl === (builtins.newName callExpr ())
+          decl === (builtins.newName.callExpr())
         })
 
         treeCopy.LocalExpression(clazz, namedDecls,

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/PatternMatcher.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/PatternMatcher.scala
@@ -22,7 +22,7 @@ object PatternMatcher extends Transformer with TreeDSL {
       }
 
       transformStat {
-        LOCAL (newCaptures:_*) IN {
+        LOCAL (newCaptures.toSeq:_*) IN {
           treeCopy.MatchStatement(matchStat, value, newClauses, elseStat)
         }
       }
@@ -53,7 +53,7 @@ object PatternMatcher extends Transformer with TreeDSL {
       }
 
       transformExpr {
-        LOCAL (newCaptures:_*) IN {
+        LOCAL (newCaptures.toSeq:_*) IN {
           treeCopy.MatchExpression(matchStat, value, newClauses, elseExpr)
         }
       }

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Transformer.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Transformer.scala
@@ -31,7 +31,7 @@ abstract class Transformer extends (Program => Unit) {
   val treeCopy = new TreeCopier
 
   /** Applies the transformation phase to a program */
-  def apply(program: Program) {
+  def apply(program: Program): Unit = {
     this.program = program
     try {
       apply()
@@ -41,7 +41,7 @@ abstract class Transformer extends (Program => Unit) {
   }
 
   /** Applies the transformation phase to the current `program` */
-  protected def apply() {
+  protected def apply(): Unit = {
     if (program.isRawCode)
       program.rawCode = transformStat(program.rawCode)
     else {
@@ -57,7 +57,7 @@ abstract class Transformer extends (Program => Unit) {
   }
 
   /** Applies the transformation phase to the current `abstraction` */
-  protected def applyToAbstraction() {
+  protected def applyToAbstraction(): Unit = {
     abstraction.body = transformStat(abstraction.body)
   }
 

--- a/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Unnester.scala
+++ b/bootcompiler/src/main/scala/org/mozartoz/bootcompiler/transform/Unnester.scala
@@ -92,7 +92,7 @@ object Unnester extends Transformer with TreeDSL {
     case failStat @ FailStatement() =>
       transformStat {
         atPos(failStat) {
-          builtins.fail call ()
+          builtins.fail.call()
         }
       }
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{
+  inputs.nixpkgs.url = "nixpkgs-22.05";
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      targetPackages = with pkgs; [ cmake scala sbt ];
+    }
+  }
+}

--- a/vm/vm/main/core-forward-decl.hh
+++ b/vm/vm/main/core-forward-decl.hh
@@ -31,13 +31,15 @@
 #endif
 #endif
 
-#include <utility>
-#include <cstdlib>
-#include <cstdint>
-#include <ostream>
-#include <functional>
-#include <memory>
 #include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <ostream>
+#include <stdexcept>
+#include <utility>
 
 #define MOZART_NORETURN __attribute__((noreturn))
 


### PR DESCRIPTION
This PR updates the project to be buildable on the latest version of the dependencies.

I have not been able to test this PR on Windows, MacOS nor OpenBSD, but I expect them to work the same as I haven't edited anything platform specific.

### Details
#### /vm
- Fix missing include directives for `std::numeric_limits`

#### /bootcompiler
- Update project to be usable with the java 9 module system
- Update SBT to 1.6.2 and scala to 1.13.8, which required changing the `sbt-onejar` build plugin to `sbt-assembly` in the process.
- Add `io.spray/spray-json` as a replacement for the deprecated json parser in `scala-parser-combinators`
- Remove deprecated JVM flags used for running sbt
- Add explicit `Unit` return types to all related functions
- Add (hopefully temporary) module exports to `jdk.internal.math`. I couldn't figure out why it is used, but the compilation crashes at OzLexical because it somehow uses this internal module directly.

### Dependency versions

Built on `x86_64_linux`

- java: openjdk 18.0.2 2022-07-19

- tcl: 8.6.12-3
- tk: 8.6.12-1 
- boost: 1.79.0-1 
- cmake: 3.24.1-1 
- gcc:  12.2.0-1
