### PR TITLE
lib: Fix switched arguments in `File.seek`

### DIFF
--- a/lib/main/op/Open.oz
+++ b/lib/main/op/Open.oz
@@ -370,11 +370,11 @@ in
             lock self.ReadLock then
                lock self.WriteLock then D=@WriteDesc in
                   if {IsInt D} then
-                     {OS.lSeek D O case W
-                                   of 'set'     then 'SEEK_SET'
-                                   [] 'current' then 'SEEK_CUR'
-                                   [] 'end'     then 'SEEK_END'
-                                   end _}
+                     {OS.lSeek D case W
+                                 of 'set'     then 'SEEK_SET'
+                                 [] 'current' then 'SEEK_CUR'
+                                 [] 'end'     then 'SEEK_END'
+                                 end O _}
                   else {RaiseClosed self seek(whence:W offset:O)}
                   end
                end


### PR DESCRIPTION
`WhenceA` and `OffsetI` arguments passed to `OS.lSeek` from `File.seek` are the wrong way around:

```oz
{OS.lSeek D O case W
              of 'set'     then 'SEEK_SET'
              [] 'current' then 'SEEK_CUR'
              [] 'end'     then 'SEEK_END'
              end _}
```

As per http://mozart2.org/mozart-v1/doc-1.4.0/system/node56.html, the offset should be passed *after* `WhenceA`.